### PR TITLE
fix: has_spdx? now looks for actual SPDX document files

### DIFF
--- a/lib/sbom_module.ex
+++ b/lib/sbom_module.ex
@@ -13,8 +13,19 @@ defmodule SbomModule do
   end
 
   def has_spdx?(repo) do
-    boms = Path.wildcard(repo.path <> "/**/*spdx*")
-    !Enum.empty?(boms)
+    # Look for actual SPDX document files, not source code files containing "spdx"
+    spdx_patterns = [
+      "/**/*.spdx.json",
+      "/**/*.spdx.xml",
+      "/**/*.spdx.rdf",
+      "/**/*.spdx.yaml",
+      "/**/*.spdx.yml",
+      "/**/*.spdx"
+    ]
+
+    Enum.any?(spdx_patterns, fn pattern ->
+      !Enum.empty?(Path.wildcard(repo.path <> pattern))
+    end)
   end
 
 end


### PR DESCRIPTION
## Summary

- Fix false positive in `has_spdx?` function that was matching source code files
- The pattern `/**/*spdx*` was matching `lib/sbom/spdx.ex` and `test/sbom/spdx_test.exs`
- Now uses specific SPDX document extensions: `.spdx.json`, `.spdx.xml`, `.spdx.rdf`, `.spdx.yaml`, `.spdx.yml`, `.spdx`

## Test plan

- [ ] CI tests pass (sbom_module_test.exs line 14 should now pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)