### PR TITLE
chore: bump version to 0.9.1 for hex publish

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule GithubModule.MixProject do
     [
       app: :lowendinsight,
       description: description(),
-      version: "0.9.0",
+      version: "0.9.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary
- Bump version from 0.9.0 to 0.9.1 to allow hex publish (0.9.0 edit window expired)

## Test plan
- [x] No code changes, version bump only
- [ ] CI passes and hex publish succeeds on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)