### PR TITLE
feat: port UDS deployment integration to umbrella repo

### DIFF
--- a/apps/lowendinsight_get/Dockerfile
+++ b/apps/lowendinsight_get/Dockerfile
@@ -66,13 +66,16 @@ RUN apk update && \
       libstdc++ \
       libgcc \
       libpq \
-      ncurses-libs
+      ncurses-libs \
+      tzdata
 
 ENV REPLACE_OS_VARS=true \
     APP_NAME=lowendinsight_get \
     ERL_AFLAGS="-proto_dist inet6_tcp" \
     DATABASE_URL="ecto://postgres:postgres@localhost/lowendinsight_get_prod" \
-    REDIS_URL="redis://localhost:6379"
+    REDIS_URL="redis://localhost:6379" \
+    TZ=UTC \
+    TZDIR=/tmp/tzdata
 
 WORKDIR /opt/app
 

--- a/apps/lowendinsight_get/README.md
+++ b/apps/lowendinsight_get/README.md
@@ -63,53 +63,31 @@ Don't forget to get fetch the dependencies:
 mix deps.get && mix run --no-halt
 ```
 
-### Production
+### Production (Docker Compose)
 
-Well, if you're at this point I'd recommend using the Docker Compose or Kubernetes deployments.  Configuration for both are found in the repo.
+The `docker-compose.yml` will spin up Redis, PostgreSQL, and LEI containers.
+You can simply run `docker-compose up` to launch things.
 
-The `docker-compose.yml` will spin up a Redis db and the LowEndInsight containers, exposing the services.  You can simply run `docker-compose up` to launch things.
+### Production (UDS / Kubernetes)
 
-Within the `k8s` subdirectory you'll find configuration files for both Redis (single node configuration) and LowEndInsight.  For example:
+LEI-GET includes a Helm chart, Zarf package, and UDS bundle for Kubernetes deployment
+with [UDS](https://github.com/defenseunicorns/uds-core) (Unicorn Delivery Service).
 
 ```bash
-➜  kubectl apply -f k8s/redis-master-deployment.yaml
-deployment.apps/redis-master created
-➜  kubectl apply -f k8s/redis-master-service.yaml
-service/redis-master created
-➜  kubectl apply -f k8s/deployment.yaml
-deployment.apps/lei-get created
-➜  kubectl apply -f k8s/service.yaml
-service/lei-get created
-➜  kubectl get all
-NAME                                READY   STATUS    RESTARTS   AGE
-pod/lei-get-7f4bd755c9-7m6fz        1/1     Running   0          23s
-pod/redis-master-7db7f6579f-x97df   1/1     Running   0          37s
+# Build Zarf package (from repo root) and deploy with the development bundle
+zarf package create . --confirm
+cd bundle && uds create . --confirm
+uds deploy uds-bundle-lei-dev-*.tar.zst --confirm
 
-
-NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
-service/kubernetes     ClusterIP      10.96.0.1       <none>        443/TCP          17d
-service/lei-get        LoadBalancer   10.96.15.135    <pending>     4000:32224/TCP   17s
-service/redis-master   ClusterIP      10.96.247.238   <none>        6379/TCP         33s
-
-
-NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/lei-get        1/1     1            1           23s
-deployment.apps/redis-master   1/1     1            1           37s
-
-NAME                                      DESIRED   CURRENT   READY   AGE
-replicaset.apps/lei-get-7f4bd755c9        1         1         1       23s
-replicaset.apps/redis-master-7db7f6579f   1         1         1       37s
+# Access at https://lei.uds.dev
 ```
 
-### Heroku
+The bundle deploys a complete stack: k3d, UDS Core (Istio, monitoring),
+PostgreSQL (Zalando operator), Valkey, and lei-get with full network policies
+and service mesh integration.
 
-It's also possible to run this in Heroku using the Elixir buildpack.  The Redis configuration requires the Heroku Redis addon which will set the REDIS_URL environment variable.  The `procfile` at the root of the repo is used by the buildpack to run the app.  While this isn't a Phoenix app I used this URL as a guide:
-
-https://hexdocs.pm/phoenix/heroku.html
-
-And this one for the Redis setup:
-
-https://devcenter.heroku.com/articles/heroku-redis#provisioning-the-add-on
+See **[Operations Guide](docs/OPERATIONS.md)** for complete UDS documentation
+including Helm values, bundle overrides, custom image builds, and architecture details.
 
 ## REST API
 

--- a/apps/lowendinsight_get/chart/Chart.yaml
+++ b/apps/lowendinsight_get/chart/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: lowendinsight-get
+description: LowEndInsight GET - OSS Supply Chain Risk Analysis API
+type: application
+version: 0.1.0
+appVersion: "0.9.3"
+home: https://github.com/kitplummer/lowendinsight-get
+sources:
+  - https://github.com/kitplummer/lowendinsight-get
+  - https://github.com/kitplummer/lowendinsight
+maintainers:
+  - name: kitplummer
+keywords:
+  - lowendinsight
+  - supply-chain
+  - security
+  - sbom
+  - risk-analysis

--- a/apps/lowendinsight_get/chart/templates/_helpers.tpl
+++ b/apps/lowendinsight_get/chart/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lei-get.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "lei-get.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lei-get.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lei-get.labels" -}}
+helm.sh/chart: {{ include "lei-get.chart" . }}
+{{ include "lei-get.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lei-get.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lei-get.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lei-get.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lei-get.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name for sensitive config
+*/}}
+{{- define "lei-get.secretName" -}}
+{{- if .Values.existingSecret }}
+{{- .Values.existingSecret }}
+{{- else }}
+{{- include "lei-get.fullname" . }}
+{{- end }}
+{{- end }}

--- a/apps/lowendinsight_get/chart/templates/configmap.yaml
+++ b/apps/lowendinsight_get/chart/templates/configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lei-get.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lei-get.labels" . | nindent 4 }}
+data:
+  PORT: {{ .Values.config.port | quote }}
+  REDIS_URL: {{ .Values.config.redisUrl | quote }}
+  DATABASE_URL: {{ .Values.config.databaseUrl | quote }}
+  LEI_CACHE_TTL: {{ .Values.config.cacheTtl | quote }}
+  LEI_CACHE_CLEAN_ENABLE: {{ .Values.config.cacheCleanEnable | quote }}
+  LEI_CHECK_REPO_SIZE: {{ .Values.config.checkRepoSize | quote }}
+  LEI_DEFAULT_CACHE_TIMEOUT: {{ .Values.config.defaultCacheTimeout | quote }}
+  LEI_WAIT_TIME: {{ .Values.config.waitTime | quote }}
+  LEI_JOBS_PER_CORE_MAX: {{ .Values.config.jobsPerCoreMax | quote }}
+  LEI_BASE_TEMP_DIR: {{ .Values.config.baseTempDir | quote }}
+  LEI_SBOM_RISK_LEVEL: {{ .Values.riskThresholds.sbomRiskLevel | quote }}
+  LEI_CRITICAL_CONTRIBUTOR_LEVEL: {{ .Values.riskThresholds.criticalContributorLevel | quote }}
+  LEI_HIGH_CONTRIBUTOR_LEVEL: {{ .Values.riskThresholds.highContributorLevel | quote }}
+  LEI_MEDIUM_CONTRIBUTOR_LEVEL: {{ .Values.riskThresholds.mediumContributorLevel | quote }}
+  LEI_CRITICAL_CURRENCY_LEVEL: {{ .Values.riskThresholds.criticalCurrencyLevel | quote }}
+  LEI_HIGH_CURRENCY_LEVEL: {{ .Values.riskThresholds.highCurrencyLevel | quote }}
+  LEI_MEDIUM_CURRENCY_LEVEL: {{ .Values.riskThresholds.mediumCurrencyLevel | quote }}
+  LEI_CRITICAL_LARGE_COMMIT_LEVEL: {{ .Values.riskThresholds.criticalLargeCommitLevel | quote }}
+  LEI_HIGH_LARGE_COMMIT_LEVEL: {{ .Values.riskThresholds.highLargeCommitLevel | quote }}
+  LEI_MEDIUM_LARGE_COMMIT_LEVEL: {{ .Values.riskThresholds.mediumLargeCommitLevel | quote }}
+  LEI_CRITICAL_FUNCTIONAL_CONTRIBUTORS_LEVEL: {{ .Values.riskThresholds.criticalFunctionalContributorsLevel | quote }}
+  LEI_HIGH_FUNCTIONAL_CONTRIBUTORS_LEVEL: {{ .Values.riskThresholds.highFunctionalContributorsLevel | quote }}
+  LEI_MEDIUM_FUNCTIONAL_CONTRIBUTORS_LEVEL: {{ .Values.riskThresholds.mediumFunctionalContributorsLevel | quote }}

--- a/apps/lowendinsight_get/chart/templates/deployment.yaml
+++ b/apps/lowendinsight_get/chart/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lei-get.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lei-get.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lei-get.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lei-get.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "lei-get.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ int .Values.config.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "lei-get.fullname" . }}
+            - secretRef:
+                name: {{ include "lei-get.secretName" . }}
+          env:
+            {{- if .Values.database.existingSecret }}
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: {{ .Values.database.secretKeys.username }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: {{ .Values.database.secretKeys.password }}
+            - name: DATABASE_URL
+              value: "ecto://$(DB_USERNAME):$(DB_PASSWORD)@{{ .Values.database.host }}:{{ .Values.database.port }}/{{ .Values.database.name }}"
+            {{- end }}
+            {{- if .Values.valkey.existingSecret }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.valkey.existingSecret }}
+                  key: {{ .Values.valkey.secretKey }}
+            - name: REDIS_URL
+              value: "redis://default:$(VALKEY_PASSWORD)@valkey-primary.valkey.svc.cluster.local:6379"
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: app-var
+              mountPath: /opt/app/var
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: app-var
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/apps/lowendinsight_get/chart/templates/hpa.yaml
+++ b/apps/lowendinsight_get/chart/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "lei-get.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lei-get.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lei-get.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/apps/lowendinsight_get/chart/templates/secret.yaml
+++ b/apps/lowendinsight_get/chart/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lei-get.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lei-get.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  SECRET_KEY_BASE: {{ .Values.secrets.secretKeyBase | quote }}
+  LEI_GH_TOKEN: {{ .Values.secrets.ghToken | quote }}
+{{- end }}

--- a/apps/lowendinsight_get/chart/templates/service.yaml
+++ b/apps/lowendinsight_get/chart/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lei-get.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lei-get.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lei-get.selectorLabels" . | nindent 4 }}

--- a/apps/lowendinsight_get/chart/templates/serviceaccount.yaml
+++ b/apps/lowendinsight_get/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lei-get.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lei-get.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/apps/lowendinsight_get/chart/values.yaml
+++ b/apps/lowendinsight_get/chart/values.yaml
@@ -1,0 +1,137 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/kitplummer/lowendinsight-get
+  tag: "0.9.3"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: "lei-get"
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 4000
+
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "250m"
+  limits:
+    memory: "1Gi"
+    cpu: "2"
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 15
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 3
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- Application configuration (environment variables)
+config:
+  # -- HTTP server port
+  port: "4000"
+  # -- Redis/Valkey connection URL (uds-package-valkey default endpoint)
+  redisUrl: "redis://valkey-primary.valkey.svc.cluster.local:6379"
+  # -- PostgreSQL connection URL (fallback if not using operator secret)
+  databaseUrl: ""
+  # -- Cache TTL in days
+  cacheTtl: "30"
+  # -- Enable cache cleanup job
+  cacheCleanEnable: "true"
+  # -- Check repo size before cloning
+  checkRepoSize: "true"
+  # -- Default cache timeout in milliseconds
+  defaultCacheTimeout: "30000"
+  # -- Analysis wait time in milliseconds
+  waitTime: "7200000"
+  # -- Max concurrent analysis jobs per core
+  jobsPerCoreMax: "1"
+  # -- Base directory for temp git clones
+  baseTempDir: "/tmp"
+
+# -- Database configuration for Zalando postgres-operator integration
+database:
+  # -- PostgreSQL host
+  host: "pg-cluster.postgres.svc.cluster.local"
+  # -- PostgreSQL port
+  port: "5432"
+  # -- Database name
+  name: "lowendinsight_get"
+  # -- Existing secret with Zalando operator credentials (username + password keys)
+  existingSecret: ""
+  # -- Key names in the existing secret
+  secretKeys:
+    username: "username"
+    password: "password"
+
+# -- Valkey/Redis configuration
+valkey:
+  # -- Existing secret with Valkey password
+  existingSecret: ""
+  # -- Key name in the existing secret
+  secretKey: "password"
+
+# -- Sensitive configuration (stored in Secret)
+secrets:
+  # -- Secret key base for signing/encryption (minimum 64 chars)
+  secretKeyBase: ""
+  # -- GitHub API token (optional, recommended for rate limits)
+  ghToken: ""
+
+# -- Use an existing secret instead of creating one
+existingSecret: ""
+
+# -- Risk threshold configuration
+riskThresholds:
+  sbomRiskLevel: "medium"
+  criticalContributorLevel: "2"
+  highContributorLevel: "3"
+  mediumContributorLevel: "5"
+  criticalCurrencyLevel: "104"
+  highCurrencyLevel: "52"
+  mediumCurrencyLevel: "26"
+  criticalLargeCommitLevel: "0.30"
+  highLargeCommitLevel: "0.15"
+  mediumLargeCommitLevel: "0.05"
+  criticalFunctionalContributorsLevel: "2"
+  highFunctionalContributorsLevel: "3"
+  mediumFunctionalContributorsLevel: "5"

--- a/apps/lowendinsight_get/docs/OPERATIONS.md
+++ b/apps/lowendinsight_get/docs/OPERATIONS.md
@@ -70,18 +70,207 @@ See `k8s/` directory for Kubernetes manifests:
 
 ### UDS (Unicorn Delivery Service)
 
-LEI-GET is designed for UDS integration:
+LEI-GET includes first-class UDS integration via a Helm chart, Zarf package, and UDS
+Package CR. Infrastructure services (PostgreSQL, Valkey) are deployed as separate
+UDS packages in the bundle — this follows the standard UDS convention used by
+GitLab, Mattermost, SonarQube, and other UDS applications.
+
+#### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  UDS Core (Istio, Pepr, Keycloak, Monitoring)               │
+├──────────┬──────────────┬──────────────┬────────────────────┤
+│ lei (ns) │ postgres (ns)│ valkey (ns)  │ istio-system (ns)  │
+│          │              │              │                     │
+│ lei-get ─┼─▶ pg-cluster │              │ tenant-gateway ◀──┐│
+│          │              │              │                    ││
+│ lei-get ─┼──────────────┼─▶ valkey     │                    ││
+│          │              │   primary    │                    ││
+│ lei-get ─┼──────────────┼──────────────┼─▶ HTTPS (443)     ││
+│  (git)   │              │              │   (git clone)      ││
+│          │              │              │                    ││
+│ ◀────────┼──────────────┼──────────────┼── lei.uds.dev ────┘│
+└──────────┴──────────────┴──────────────┴────────────────────┘
+```
+
+**Key files:**
+
+| File | Purpose |
+|------|---------|
+| `apps/lowendinsight_get/chart/` | Helm chart for lei-get deployment |
+| `zarf.yaml` | Zarf package definition (wraps Helm chart + images + UDS Package CR) |
+| `apps/lowendinsight_get/uds-package.yaml` | UDS Package CR (network policies, virtual service, monitoring) |
+| `bundle/uds-bundle.yaml` | Development bundle (k3d + UDS Core + postgres + valkey + lei-get) |
+
+#### Prerequisites
+
+- [UDS CLI](https://github.com/defenseunicorns/uds-cli) (`uds` command)
+- [Zarf](https://zarf.dev) (`zarf` command)
+- Docker (for building images and running k3d)
+
+#### Quick Start (Development Bundle)
+
+The development bundle creates a complete local environment with k3d:
+
+```bash
+# 1. Build the Zarf package (from repo root)
+zarf package create . --confirm
+
+# 2. Create the UDS bundle
+cd bundle
+uds create . --confirm
+
+# 3. Deploy everything (k3d cluster, UDS Core, PostgreSQL, Valkey, lei-get)
+uds deploy uds-bundle-lei-dev-*.tar.zst --confirm
+
+# 4. Access the app
+curl -sk https://lei.uds.dev/
+```
+
+The bundle deploys in order:
+1. **uds-k3d** — Local k3d cluster with load balancer
+2. **init** — Zarf init package (internal registry, agent)
+3. **core** — UDS Core (Istio, Pepr operator, monitoring)
+4. **postgres-operator** — Zalando PostgreSQL operator + `pg-cluster` instance
+5. **valkey** — Valkey (Redis-compatible) with password copied to `lei` namespace
+6. **lei-get** — LEI application with Helm chart + UDS Package CR
+
+#### Helm Chart Configuration
+
+The Helm chart is in `apps/lowendinsight_get/chart/` and supports both standalone and UDS deployments.
+
+**Database credentials (Zalando operator):**
+
+When using the Zalando postgres-operator, credentials are auto-generated and stored
+in a Kubernetes secret. The chart wires these into the `DATABASE_URL` using
+Kubernetes variable substitution:
 
 ```yaml
-# zarf.yaml example
-components:
-  - name: lei-get
-    charts:
-      - name: lei-get
-        valuesFiles:
-          - values.yaml
-    images:
-      - ghcr.io/kitplummer/lowendinsight-get:latest
+# In bundle overrides or helm install --set:
+database:
+  existingSecret: "lei.lei.pg-cluster.credentials.postgresql.acid.zalan.do"
+
+# The deployment template constructs DATABASE_URL automatically:
+# ecto://$(DB_USERNAME):$(DB_PASSWORD)@pg-cluster.postgres.svc.cluster.local:5432/lowendinsight_get
+```
+
+**Valkey credentials (copied secret):**
+
+The UDS valkey package can copy the password to the `lei` namespace. The chart
+constructs `REDIS_URL` with proper ACL auth:
+
+```yaml
+valkey:
+  existingSecret: "lei-valkey-password"
+
+# Produces: redis://default:$(VALKEY_PASSWORD)@valkey-primary.valkey.svc.cluster.local:6379
+```
+
+**Key values:**
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `fullnameOverride` | `"lei-get"` | Resource name (must match UDS Package CR service name) |
+| `image.tag` | `"0.9.3"` | Container image tag |
+| `config.port` | `"4000"` | HTTP server port |
+| `config.cacheTtl` | `"30"` | Cache TTL in days |
+| `config.waitTime` | `"7200000"` | Analysis wait time (ms) |
+| `database.existingSecret` | `""` | Zalando operator credentials secret name |
+| `valkey.existingSecret` | `""` | Valkey password secret name |
+| `secrets.secretKeyBase` | `""` | Secret key for signing (min 64 chars) |
+| `secrets.ghToken` | `""` | GitHub API token |
+
+See `apps/lowendinsight_get/chart/values.yaml` for the complete list with descriptions.
+
+#### UDS Package CR
+
+The `apps/lowendinsight_get/uds-package.yaml` defines network policies and service exposure for the UDS
+Pepr operator:
+
+- **Ingress**: Exposed via Istio tenant gateway at `lei.<domain>` (port 4000)
+- **Egress**: DNS (53), Valkey (6379), PostgreSQL (5432), HTTPS (443 for git clone)
+- **Monitoring**: ServiceMonitor on port 4000
+
+#### Bundle Overrides
+
+The bundle wires infrastructure services to lei-get via overrides:
+
+```yaml
+# postgres-operator: create database and user, allow ingress from lei namespace
+- path: postgresql
+  value:
+    databases:
+      lowendinsight_get: lei.lei
+    ingress:
+      - remoteNamespace: lei
+
+# valkey: copy password to lei namespace, allow ingress from lei namespace
+- path: copyPassword
+  value:
+    enabled: true
+    namespace: lei
+    secretName: lei-valkey-password
+- path: additionalNetworkAllow
+  value:
+    - direction: Ingress
+      selector:
+        app.kubernetes.io/name: valkey
+      remoteNamespace: lei
+      remoteSelector:
+        app.kubernetes.io/name: lowendinsight-get
+      port: 6379
+
+# lei-get: use operator-managed secrets
+- path: database.existingSecret
+  value: "lei.lei.pg-cluster.credentials.postgresql.acid.zalan.do"
+- path: valkey.existingSecret
+  value: "lei-valkey-password"
+```
+
+#### Security Context
+
+The container runs with a hardened security context:
+- `readOnlyRootFilesystem: true` — writable paths via emptyDir: `/tmp`, `/opt/app/var`
+- `runAsNonRoot: true` (UID 1000)
+- All capabilities dropped
+- tzdata configured to write to `/tmp/tzdata`
+
+#### Startup Resilience
+
+The application starts the OTP supervisor tree (including the Ecto Repo connection
+pool) before running database migrations. Migrations retry up to 10 times with
+2-second delays, handling transient connectivity issues common in service mesh
+environments (e.g., Istio ambient mode where ztunnel networking takes a moment
+to initialize for new pods).
+
+#### Building a Custom Image
+
+```bash
+# Build (from repo root)
+docker build -f apps/lowendinsight_get/Dockerfile -t ghcr.io/kitplummer/lowendinsight-get:0.9.3-dev .
+
+# Push to Zarf internal registry (for dev cluster testing)
+kubectl port-forward svc/zarf-docker-registry -n zarf 5000:5000 &
+ZARF_PASS=$(kubectl get secret zarf-state -n zarf -o jsonpath='{.data.state}' \
+  | base64 -d | python3 -c "import sys,json; print(json.load(sys.stdin)['registryInfo']['pushPassword'])")
+echo "$ZARF_PASS" | docker login localhost:5000 -u zarf-push --password-stdin
+docker tag ghcr.io/kitplummer/lowendinsight-get:0.9.3-dev \
+  localhost:5000/kitplummer/lowendinsight-get:0.9.3-dev
+docker push localhost:5000/kitplummer/lowendinsight-get:0.9.3-dev
+
+# Deploy with Helm
+helm upgrade lei-get apps/lowendinsight_get/chart/ -n lei \
+  --set image.tag=0.9.3-dev \
+  --set database.existingSecret="lei.lei.pg-cluster.credentials.postgresql.acid.zalan.do" \
+  --set valkey.existingSecret="lei-valkey-password"
+```
+
+#### Teardown
+
+```bash
+# Remove the k3d cluster (removes everything)
+k3d cluster delete uds
 ```
 
 ## Configuration

--- a/apps/lowendinsight_get/lib/lowendinsight_get/application.ex
+++ b/apps/lowendinsight_get/lib/lowendinsight_get/application.ex
@@ -8,12 +8,27 @@ defmodule LowendinsightGet.Application do
   require Logger
 
   def start(_type, _args) do
-    {:ok, _, _} =
-      Ecto.Migrator.with_repo(LowendinsightGet.Repo, fn repo ->
-        Ecto.Migrator.run(repo, Ecto.Migrator.migrations_path(repo), :up, all: true)
-      end)
+    {:ok, pid} = Supervisor.start_link(children(), opts())
+    run_migrations()
+    {:ok, pid}
+  end
 
-    Supervisor.start_link(children(), opts())
+  defp run_migrations(retries \\ 10, delay \\ 2_000) do
+    Ecto.Migrator.run(
+      LowendinsightGet.Repo,
+      Ecto.Migrator.migrations_path(LowendinsightGet.Repo),
+      :up,
+      all: true
+    )
+  rescue
+    e ->
+      if retries > 0 do
+        Logger.warning("Database not ready, retrying in #{delay}ms... (#{retries} attempts left)")
+        Process.sleep(delay)
+        run_migrations(retries - 1, delay)
+      else
+        reraise e, __STACKTRACE__
+      end
   end
 
   defp children do

--- a/apps/lowendinsight_get/uds-package.yaml
+++ b/apps/lowendinsight_get/uds-package.yaml
@@ -1,0 +1,57 @@
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: lei-get
+  namespace: lei
+spec:
+  network:
+    expose:
+      - service: lei-get
+        selector:
+          app.kubernetes.io/name: lowendinsight-get
+        gateway: tenant
+        host: lei
+        port: 4000
+    allow:
+      # DNS
+      - direction: Egress
+        selector:
+          app.kubernetes.io/name: lowendinsight-get
+        remoteNamespace: kube-system
+        remoteSelector:
+          k8s-app: kube-dns
+        port: 53
+        description: "DNS lookup"
+      # Valkey/Redis
+      - direction: Egress
+        selector:
+          app.kubernetes.io/name: lowendinsight-get
+        remoteNamespace: valkey
+        port: 6379
+        description: "Valkey cache"
+      # PostgreSQL
+      - direction: Egress
+        selector:
+          app.kubernetes.io/name: lowendinsight-get
+        remoteNamespace: postgres
+        port: 5432
+        description: "PostgreSQL database"
+      # Intra-namespace
+      - direction: Ingress
+        remoteGenerated: IntraNamespace
+        description: "Intra-namespace traffic"
+      # HTTPS egress for git clone operations
+      - direction: Egress
+        selector:
+          app.kubernetes.io/name: lowendinsight-get
+        port: 443
+        description: "HTTPS egress for git clone"
+
+  monitor:
+    - selector:
+        app.kubernetes.io/name: lowendinsight-get
+      targetPort: 4000
+      portName: http
+      path: /
+      description: "lei-get-metrics"
+      kind: ServiceMonitor

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -1,0 +1,79 @@
+kind: UDSBundle
+metadata:
+  name: lei-dev
+  description: "LEI development bundle with k3d, UDS Core slim, and lei-get"
+  version: 0.1.0
+  architecture: arm64
+
+packages:
+  - name: uds-k3d
+    repository: ghcr.io/defenseunicorns/packages/uds-k3d
+    ref: 0.19.4
+
+  - name: init
+    repository: ghcr.io/zarf-dev/packages/init
+    ref: v0.43.0
+
+  - name: core
+    repository: ghcr.io/defenseunicorns/packages/uds/core
+    ref: 0.61.0-upstream
+    optionalComponents:
+      - metrics-server
+
+  - name: postgres-operator
+    repository: ghcr.io/uds-packages/postgres-operator
+    ref: 1.15.1-uds.1-upstream
+    overrides:
+      postgres-operator:
+        uds-postgres-config:
+          values:
+            - path: postgresql
+              value:
+                enabled: true
+                teamId: "uds"
+                numberOfInstances: 1
+                users:
+                  lei.lei: []
+                databases:
+                  lowendinsight_get: lei.lei
+                version: "16"
+                volume:
+                  size: 1Gi
+                ingress:
+                  - remoteNamespace: lei
+
+  - name: valkey
+    repository: ghcr.io/uds-packages/valkey
+    ref: 8.1.3-uds.2-upstream
+    overrides:
+      valkey:
+        uds-valkey-config:
+          values:
+            - path: copyPassword
+              value:
+                enabled: true
+                namespace: lei
+                secretName: lei-valkey-password
+                secretKey: password
+            - path: additionalNetworkAllow
+              value:
+                - direction: Ingress
+                  selector:
+                    app.kubernetes.io/name: valkey
+                  remoteNamespace: lei
+                  remoteSelector:
+                    app.kubernetes.io/name: lowendinsight-get
+                  port: 6379
+                  description: "LEI app access to Valkey"
+
+  - name: lei-get
+    path: ./
+    ref: 0.9.3
+    overrides:
+      lei-get:
+        lei-get:
+          values:
+            - path: database.existingSecret
+              value: "lei.lei.pg-cluster.credentials.postgresql.acid.zalan.do"
+            - path: valkey.existingSecret
+              value: "lei-valkey-password"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -1,0 +1,31 @@
+kind: ZarfPackageConfig
+metadata:
+  name: lei-get
+  description: "LowEndInsight GET - OSS Supply Chain Risk Analysis API"
+  version: "0.9.3"
+  url: https://github.com/kitplummer/lowendinsight
+
+components:
+  - name: lei-get
+    required: true
+    description: "LEI-GET API service with UDS integration"
+    charts:
+      - name: lei-get
+        localPath: apps/lowendinsight_get/chart/
+        namespace: lei
+        version: 0.1.0
+    images:
+      - ghcr.io/kitplummer/lowendinsight-get:0.9.3
+    manifests:
+      - name: uds-package
+        files:
+          - apps/lowendinsight_get/uds-package.yaml
+    actions:
+      onDeploy:
+        after:
+          - wait:
+              cluster:
+                kind: deployment
+                name: lei-get
+                namespace: lei
+                condition: available


### PR DESCRIPTION
## Summary

- Port all UDS deployment work (Helm chart, Zarf package, UDS bundle, network policies, docs) from the defunct standalone `lowendinsight-get` repo into the umbrella structure
- Fix `application.ex` startup resilience: supervisor-first pattern with migration retry loop (10x, 2s) to handle Istio ambient mesh race conditions
- Add `tzdata` to Dockerfile runtime for read-only root filesystem compatibility in hardened containers

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Startup fix | `application.ex` | Supervisor starts before migrations; retries handle mesh/DB delays |
| Helm chart | `apps/lowendinsight_get/chart/` (9 files) | Full production chart with Zalando PG operator + Valkey secret wiring |
| Zarf | `zarf.yaml` | Package config with umbrella-relative paths |
| UDS Package | `apps/lowendinsight_get/uds-package.yaml` | Network policies (DNS, Valkey, PG, HTTPS) + Istio tenant gateway |
| Bundle | `bundle/uds-bundle.yaml` | Dev bundle: k3d + UDS Core + postgres-operator + Valkey + lei-get |
| Dockerfile | `apps/lowendinsight_get/Dockerfile` | Added `tzdata`, `TZ=UTC`, `TZDIR=/tmp/tzdata` |
| Docs | `OPERATIONS.md`, `README.md` | Comprehensive UDS section replacing stubs |

## Test plan

- [x] `mix compile` succeeds from umbrella root (no errors, only pre-existing warnings)
- [x] `helm template apps/lowendinsight_get/chart/` renders all resources correctly
- [x] `zarf.yaml` paths resolve relative to repo root
- [ ] Full bundle deploy: `zarf package create . --confirm && cd bundle && uds create . && uds deploy ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)