### PR TITLE
feat(auth): scope enforcement, rate limiting, and self-registration API

### DIFF
--- a/lib/lei/api_keys.ex
+++ b/lib/lei/api_keys.ex
@@ -2,6 +2,10 @@ defmodule Lei.ApiKeys do
   import Ecto.Query
   alias Lei.{Repo, Org, ApiKey}
 
+  def get_org_by_slug(slug) do
+    Repo.get_by(Org, slug: slug)
+  end
+
   def find_or_create_org(name) do
     slug =
       name

--- a/lib/lei/application.ex
+++ b/lib/lei/application.ex
@@ -10,7 +10,7 @@ defmodule Lei.Application do
   def start(_type, _args) do
     port = Application.get_env(:lowendinsight, :http_port, 4000)
 
-    base = [Lei.Repo, Lei.BatchCache]
+    base = [Lei.Repo, Lei.BatchCache, Lei.RateLimiter]
 
     children =
       if Application.get_env(:lowendinsight, :start_http, false) do

--- a/lib/lei/auth.ex
+++ b/lib/lei/auth.ex
@@ -2,6 +2,13 @@ defmodule Lei.Auth do
   import Plug.Conn
   require Logger
 
+  @scope_map %{
+    {"/v1/analyze", "POST"} => "analyze",
+    {"/v1/health", "GET"} => nil,
+    {"/v1/orgs", "POST"} => "admin",
+    {"/v1/orgs", "GET"} => "admin"
+  }
+
   def init(opts), do: opts
 
   def call(%Plug.Conn{request_path: path} = conn, _opts) do
@@ -9,6 +16,8 @@ defmodule Lei.Auth do
       conn
       |> get_auth_header()
       |> authenticate()
+      |> check_scope()
+      |> check_rate_limit()
     else
       conn
     end
@@ -52,10 +61,79 @@ defmodule Lei.Auth do
     send_401(conn)
   end
 
+  defp check_scope(%Plug.Conn{halted: true} = conn), do: conn
+
+  defp check_scope(conn) do
+    required = required_scope(conn)
+
+    cond do
+      # No scope required for this endpoint
+      is_nil(required) ->
+        conn
+
+      # JWT auth skips scope check (full access)
+      conn.assigns[:auth_method] != :api_key ->
+        conn
+
+      # API key — check scopes
+      true ->
+        scopes = conn.assigns[:current_api_key].scopes
+
+        if required in scopes or "admin" in scopes do
+          conn
+        else
+          send_403(conn, %{error: "insufficient scope", required: required})
+        end
+    end
+  end
+
+  defp check_rate_limit(%Plug.Conn{halted: true} = conn), do: conn
+
+  defp check_rate_limit(conn) do
+    # Only rate-limit API key auth; JWT is internal/trusted
+    if conn.assigns[:auth_method] == :api_key do
+      api_key = conn.assigns[:current_api_key]
+      tier = api_key.org.tier
+
+      case Lei.RateLimiter.check(api_key.key_prefix, tier) do
+        {:ok, remaining} ->
+          conn
+          |> put_resp_header("x-ratelimit-remaining", to_string(remaining))
+
+        {:error, :rate_limited, retry_after} ->
+          retry_secs = div(retry_after, 1000) + 1
+
+          conn
+          |> put_resp_header("retry-after", to_string(retry_secs))
+          |> put_resp_content_type("application/json")
+          |> send_resp(429, Poison.encode!(%{error: "rate limit exceeded", retry_after: retry_secs}))
+          |> halt()
+      end
+    else
+      conn
+    end
+  end
+
+  defp required_scope(conn) do
+    # Match path prefix (e.g., /v1/analyze/batch matches /v1/analyze)
+    Enum.find_value(@scope_map, fn {{prefix, method}, scope} ->
+      if String.starts_with?(conn.request_path, prefix) and conn.method == method do
+        scope
+      end
+    end)
+  end
+
   defp send_401(conn, data \\ %{message: "authentication required"}) do
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(401, Poison.encode!(data))
+    |> halt()
+  end
+
+  defp send_403(conn, data) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(403, Poison.encode!(data))
     |> halt()
   end
 end

--- a/lib/lei/rate_limiter.ex
+++ b/lib/lei/rate_limiter.ex
@@ -1,0 +1,110 @@
+defmodule Lei.RateLimiter do
+  @moduledoc """
+  ETS-based sliding window rate limiter.
+
+  Tracks request counts per key (API key prefix or IP) within a
+  configurable window. Limits are tier-based: free keys get fewer
+  requests per window than pro keys.
+  """
+  use GenServer
+
+  @table :lei_rate_limiter
+  @default_window_ms 60_000
+  @default_limits %{free: 60, pro: 600}
+  @cleanup_interval_ms 120_000
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Check if a request is allowed under the rate limit.
+  Returns {:ok, remaining} or {:error, :rate_limited, retry_after_ms}.
+  """
+  def check(key, tier \\ "free") do
+    now = System.monotonic_time(:millisecond)
+    window = window_ms()
+    limit = limit_for(tier)
+    cutoff = now - window
+
+    # Get current count in window
+    case :ets.lookup(@table, key) do
+      [{^key, timestamps}] ->
+        # Filter to only timestamps within window
+        recent = Enum.filter(timestamps, &(&1 > cutoff))
+        count = length(recent)
+
+        if count < limit do
+          :ets.insert(@table, {key, [now | recent]})
+          {:ok, limit - count - 1}
+        else
+          oldest = Enum.min(recent)
+          retry_after = oldest + window - now
+          {:error, :rate_limited, max(retry_after, 0)}
+        end
+
+      [] ->
+        :ets.insert(@table, {key, [now]})
+        {:ok, limit - 1}
+    end
+  end
+
+  @doc "Reset rate limit state for a key (useful in tests)."
+  def reset(key) do
+    :ets.delete(@table, key)
+    :ok
+  end
+
+  @doc "Clear all rate limit state."
+  def clear do
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  defp window_ms do
+    Application.get_env(:lowendinsight, :rate_limit_window_ms, @default_window_ms)
+  end
+
+  defp limit_for(tier) do
+    limits = Application.get_env(:lowendinsight, :rate_limits, @default_limits)
+    Map.get(limits, String.to_existing_atom(tier), @default_limits.free)
+  rescue
+    ArgumentError -> @default_limits.free
+  end
+
+  # GenServer callbacks
+
+  @impl true
+  def init(_opts) do
+    :ets.new(@table, [:named_table, :public, :set])
+    schedule_cleanup()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:cleanup, state) do
+    now = System.monotonic_time(:millisecond)
+    cutoff = now - window_ms()
+
+    :ets.foldl(
+      fn {key, timestamps}, _acc ->
+        recent = Enum.filter(timestamps, &(&1 > cutoff))
+
+        if Enum.empty?(recent) do
+          :ets.delete(@table, key)
+        else
+          :ets.insert(@table, {key, recent})
+        end
+      end,
+      nil,
+      @table
+    )
+
+    schedule_cleanup()
+    {:noreply, state}
+  end
+
+  defp schedule_cleanup do
+    Process.send_after(self(), :cleanup, @cleanup_interval_ms)
+  end
+end

--- a/lib/lei/web/router.ex
+++ b/lib/lei/web/router.ex
@@ -37,6 +37,91 @@ defmodule Lei.Web.Router do
     |> send_resp(200, Poison.encode!(%{status: "ok", cache: stats}))
   end
 
+  # --- Self-registration endpoints ---
+
+  post "/v1/orgs" do
+    case conn.body_params do
+      %{"name" => name} when is_binary(name) and name != "" ->
+        case Lei.ApiKeys.find_or_create_org(name) do
+          {:ok, org} ->
+            json_resp(conn, 201, %{
+              id: org.id,
+              name: org.name,
+              slug: org.slug,
+              tier: org.tier
+            })
+
+          {:error, changeset} ->
+            json_resp(conn, 422, %{error: format_errors(changeset)})
+        end
+
+      _ ->
+        json_resp(conn, 400, %{error: "missing required field: name"})
+    end
+  end
+
+  post "/v1/orgs/:slug/keys" do
+    case Lei.ApiKeys.get_org_by_slug(slug) do
+      nil ->
+        json_resp(conn, 404, %{error: "org not found"})
+
+      org ->
+        name = get_in(conn.body_params, ["name"]) || "default"
+        scopes = get_in(conn.body_params, ["scopes"]) || []
+
+        case Lei.ApiKeys.create_api_key(org, name, scopes) do
+          {:ok, raw_key, api_key} ->
+            json_resp(conn, 201, %{
+              key: raw_key,
+              name: api_key.name,
+              key_prefix: api_key.key_prefix,
+              scopes: api_key.scopes,
+              warning: "Store this key securely. It will not be shown again."
+            })
+
+          {:error, changeset} ->
+            json_resp(conn, 422, %{error: format_errors(changeset)})
+        end
+    end
+  end
+
+  get "/v1/orgs/:slug/keys" do
+    case Lei.ApiKeys.get_org_by_slug(slug) do
+      nil ->
+        json_resp(conn, 404, %{error: "org not found"})
+
+      org ->
+        keys = Lei.ApiKeys.list_keys(org)
+
+        json_resp(conn, 200, %{
+          keys:
+            Enum.map(keys, fn k ->
+              %{
+                id: k.id,
+                name: k.name,
+                key_prefix: k.key_prefix,
+                scopes: k.scopes,
+                active: k.active,
+                last_used_at: k.last_used_at
+              }
+            end)
+        })
+    end
+  end
+
+  delete "/v1/orgs/:slug/keys/:key_id" do
+    case Lei.ApiKeys.get_org_by_slug(slug) do
+      nil ->
+        json_resp(conn, 404, %{error: "org not found"})
+
+      _org ->
+        case Lei.ApiKeys.revoke_key(key_id) do
+          {:ok, _} -> json_resp(conn, 200, %{status: "revoked"})
+          {:error, :not_found} -> json_resp(conn, 404, %{error: "key not found"})
+        end
+    end
+  end
+
   match _ do
     conn
     |> put_resp_content_type("application/json")
@@ -74,4 +159,18 @@ defmodule Lei.Web.Router do
   end
 
   defp valid_dependency?(_), do: false
+
+  defp json_resp(conn, status, data) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Poison.encode!(data))
+  end
+
+  defp format_errors(%Ecto.Changeset{} = changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
 end

--- a/test/lei/auth_test.exs
+++ b/test/lei/auth_test.exs
@@ -8,9 +8,10 @@ defmodule Lei.AuthTest do
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Lei.Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Lei.Repo, {:shared, self()})
+    Lei.RateLimiter.clear()
 
     {:ok, org} = Lei.ApiKeys.find_or_create_org("Auth Test Org")
-    {:ok, raw_key, _api_key} = Lei.ApiKeys.create_api_key(org, "auth-test-key")
+    {:ok, raw_key, _api_key} = Lei.ApiKeys.create_api_key(org, "auth-test-key", ["analyze", "admin"])
     %{raw_key: raw_key}
   end
 
@@ -64,5 +65,49 @@ defmodule Lei.AuthTest do
       |> Auth.call(%{})
 
     refute conn.halted
+  end
+
+  test "sets x-ratelimit-remaining header for API key auth", %{raw_key: raw_key} do
+    conn =
+      conn(:get, "/v1/health")
+      |> put_req_header("authorization", "Bearer #{raw_key}")
+      |> Auth.call(%{})
+
+    assert get_resp_header(conn, "x-ratelimit-remaining") != []
+  end
+
+  test "rate limits API key after exceeding limit" do
+    {:ok, org} = Lei.ApiKeys.find_or_create_org("Rate Limit Org")
+    {:ok, raw_key, _} = Lei.ApiKeys.create_api_key(org, "rate-test", ["analyze", "admin"])
+
+    Application.put_env(:lowendinsight, :rate_limits, %{free: 2, pro: 600})
+
+    # First two requests should work
+    conn1 =
+      conn(:get, "/v1/health")
+      |> put_req_header("authorization", "Bearer #{raw_key}")
+      |> Auth.call(%{})
+
+    refute conn1.halted
+
+    conn2 =
+      conn(:get, "/v1/health")
+      |> put_req_header("authorization", "Bearer #{raw_key}")
+      |> Auth.call(%{})
+
+    refute conn2.halted
+
+    # Third should be rate limited
+    conn3 =
+      conn(:get, "/v1/health")
+      |> put_req_header("authorization", "Bearer #{raw_key}")
+      |> Auth.call(%{})
+
+    assert conn3.status == 429
+    assert conn3.halted
+    body = Poison.decode!(conn3.resp_body)
+    assert body["error"] == "rate limit exceeded"
+
+    Application.delete_env(:lowendinsight, :rate_limits)
   end
 end

--- a/test/lei/rate_limiter_test.exs
+++ b/test/lei/rate_limiter_test.exs
@@ -1,0 +1,79 @@
+defmodule Lei.RateLimiterTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    Lei.RateLimiter.clear()
+    :ok
+  end
+
+  test "allows requests under limit" do
+    assert {:ok, _remaining} = Lei.RateLimiter.check("test-key", "free")
+  end
+
+  test "decrements remaining count" do
+    {:ok, first} = Lei.RateLimiter.check("counter-key", "free")
+    {:ok, second} = Lei.RateLimiter.check("counter-key", "free")
+    assert second == first - 1
+  end
+
+  test "blocks when limit exceeded" do
+    # Use a tiny custom limit
+    Application.put_env(:lowendinsight, :rate_limits, %{free: 3, pro: 600})
+
+    assert {:ok, 2} = Lei.RateLimiter.check("limited-key", "free")
+    assert {:ok, 1} = Lei.RateLimiter.check("limited-key", "free")
+    assert {:ok, 0} = Lei.RateLimiter.check("limited-key", "free")
+    assert {:error, :rate_limited, _retry} = Lei.RateLimiter.check("limited-key", "free")
+
+    Application.delete_env(:lowendinsight, :rate_limits)
+  end
+
+  test "pro tier gets higher limit" do
+    Application.put_env(:lowendinsight, :rate_limits, %{free: 2, pro: 5})
+
+    # Free gets blocked after 2
+    Lei.RateLimiter.check("free-key", "free")
+    Lei.RateLimiter.check("free-key", "free")
+    assert {:error, :rate_limited, _} = Lei.RateLimiter.check("free-key", "free")
+
+    # Pro still has room
+    Lei.RateLimiter.check("pro-key", "pro")
+    Lei.RateLimiter.check("pro-key", "pro")
+    assert {:ok, _} = Lei.RateLimiter.check("pro-key", "pro")
+
+    Application.delete_env(:lowendinsight, :rate_limits)
+  end
+
+  test "different keys are independent" do
+    Application.put_env(:lowendinsight, :rate_limits, %{free: 1, pro: 600})
+
+    assert {:ok, 0} = Lei.RateLimiter.check("key-a", "free")
+    assert {:error, :rate_limited, _} = Lei.RateLimiter.check("key-a", "free")
+    # Different key still works
+    assert {:ok, 0} = Lei.RateLimiter.check("key-b", "free")
+
+    Application.delete_env(:lowendinsight, :rate_limits)
+  end
+
+  test "reset clears state for a key" do
+    Application.put_env(:lowendinsight, :rate_limits, %{free: 1, pro: 600})
+
+    assert {:ok, 0} = Lei.RateLimiter.check("reset-key", "free")
+    assert {:error, :rate_limited, _} = Lei.RateLimiter.check("reset-key", "free")
+    Lei.RateLimiter.reset("reset-key")
+    assert {:ok, 0} = Lei.RateLimiter.check("reset-key", "free")
+
+    Application.delete_env(:lowendinsight, :rate_limits)
+  end
+
+  test "returns retry_after when rate limited" do
+    Application.put_env(:lowendinsight, :rate_limits, %{free: 1, pro: 600})
+
+    Lei.RateLimiter.check("retry-key", "free")
+    assert {:error, :rate_limited, retry_after} = Lei.RateLimiter.check("retry-key", "free")
+    assert is_integer(retry_after)
+    assert retry_after >= 0
+
+    Application.delete_env(:lowendinsight, :rate_limits)
+  end
+end

--- a/test/lei/registration_test.exs
+++ b/test/lei/registration_test.exs
@@ -1,0 +1,155 @@
+defmodule Lei.RegistrationTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  @opts Lei.Web.Router.init([])
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Lei.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Lei.Repo, {:shared, self()})
+    Lei.RateLimiter.clear()
+
+    # Create admin key for authenticated requests
+    {:ok, org} = Lei.ApiKeys.find_or_create_org("Admin Org")
+    {:ok, admin_key, _} = Lei.ApiKeys.create_api_key(org, "admin", ["admin"])
+    %{admin_key: admin_key, org: org}
+  end
+
+  describe "POST /v1/orgs" do
+    test "creates a new org", %{admin_key: key} do
+      conn =
+        conn(:post, "/v1/orgs", Poison.encode!(%{name: "Test Organization"}))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 201
+      body = Poison.decode!(conn.resp_body)
+      assert body["name"] == "Test Organization"
+      assert body["slug"] == "test-organization"
+      assert body["tier"] == "free"
+    end
+
+    test "returns existing org if slug matches", %{admin_key: key} do
+      conn1 =
+        conn(:post, "/v1/orgs", Poison.encode!(%{name: "Dupe Org"}))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      conn2 =
+        conn(:post, "/v1/orgs", Poison.encode!(%{name: "Dupe Org"}))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      body1 = Poison.decode!(conn1.resp_body)
+      body2 = Poison.decode!(conn2.resp_body)
+      assert body1["id"] == body2["id"]
+    end
+
+    test "returns 400 when name missing", %{admin_key: key} do
+      conn =
+        conn(:post, "/v1/orgs", Poison.encode!(%{}))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 400
+    end
+  end
+
+  describe "POST /v1/orgs/:slug/keys" do
+    test "creates an API key for org", %{admin_key: key, org: org} do
+      conn =
+        conn(:post, "/v1/orgs/#{org.slug}/keys", Poison.encode!(%{name: "ci-key", scopes: ["analyze"]}))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 201
+      body = Poison.decode!(conn.resp_body)
+      assert String.starts_with?(body["key"], "lei_")
+      assert body["name"] == "ci-key"
+      assert body["scopes"] == ["analyze"]
+      assert body["warning"] =~ "not be shown again"
+    end
+
+    test "returns 404 for nonexistent org", %{admin_key: key} do
+      conn =
+        conn(:post, "/v1/orgs/nonexistent-org/keys", Poison.encode!(%{name: "test"}))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 404
+    end
+
+    test "uses default name when not provided", %{admin_key: key, org: org} do
+      conn =
+        conn(:post, "/v1/orgs/#{org.slug}/keys", Poison.encode!(%{}))
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 201
+      body = Poison.decode!(conn.resp_body)
+      assert body["name"] == "default"
+    end
+  end
+
+  describe "GET /v1/orgs/:slug/keys" do
+    test "lists keys for org", %{admin_key: key, org: org} do
+      Lei.ApiKeys.create_api_key(org, "key-1", ["analyze"])
+      Lei.ApiKeys.create_api_key(org, "key-2", ["analyze", "admin"])
+
+      conn =
+        conn(:get, "/v1/orgs/#{org.slug}/keys")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 200
+      body = Poison.decode!(conn.resp_body)
+      # admin key + 2 created = at least 3
+      assert length(body["keys"]) >= 3
+      first = hd(body["keys"])
+      assert Map.has_key?(first, "name")
+      assert Map.has_key?(first, "key_prefix")
+      refute Map.has_key?(first, "key_hash")
+    end
+
+    test "returns 404 for nonexistent org", %{admin_key: key} do
+      conn =
+        conn(:get, "/v1/orgs/nonexistent/keys")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 404
+    end
+  end
+
+  describe "DELETE /v1/orgs/:slug/keys/:key_id" do
+    test "revokes a key", %{admin_key: key, org: org} do
+      {:ok, _raw, api_key} = Lei.ApiKeys.create_api_key(org, "to-revoke")
+
+      conn =
+        conn(:delete, "/v1/orgs/#{org.slug}/keys/#{api_key.id}")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 200
+      body = Poison.decode!(conn.resp_body)
+      assert body["status"] == "revoked"
+    end
+
+    test "returns 404 for nonexistent key", %{admin_key: key, org: org} do
+      conn =
+        conn(:delete, "/v1/orgs/#{org.slug}/keys/999999")
+        |> put_req_header("authorization", "Bearer #{key}")
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status == 404
+    end
+  end
+end

--- a/test/lei/scope_test.exs
+++ b/test/lei/scope_test.exs
@@ -1,0 +1,73 @@
+defmodule Lei.ScopeTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Lei.Auth
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Lei.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Lei.Repo, {:shared, self()})
+    Lei.RateLimiter.clear()
+
+    {:ok, org} = Lei.ApiKeys.find_or_create_org("Scope Test Org")
+    {:ok, analyze_key, _} = Lei.ApiKeys.create_api_key(org, "analyze-only", ["analyze"])
+    {:ok, admin_key, _} = Lei.ApiKeys.create_api_key(org, "admin-key", ["admin"])
+    {:ok, no_scope_key, _} = Lei.ApiKeys.create_api_key(org, "no-scope-key", [])
+
+    %{analyze_key: analyze_key, admin_key: admin_key, no_scope_key: no_scope_key}
+  end
+
+  test "API key with 'analyze' scope can access /v1/analyze/*", %{analyze_key: key} do
+    conn =
+      conn(:post, "/v1/analyze/batch")
+      |> put_req_header("authorization", "Bearer #{key}")
+      |> Auth.call(%{})
+
+    refute conn.status == 403
+  end
+
+  test "API key without 'analyze' scope cannot access /v1/analyze/*", %{no_scope_key: key} do
+    conn =
+      conn(:post, "/v1/analyze/batch")
+      |> put_req_header("authorization", "Bearer #{key}")
+      |> Auth.call(%{})
+
+    assert conn.status == 403
+    body = Poison.decode!(conn.resp_body)
+    assert body["error"] == "insufficient scope"
+    assert body["required"] == "analyze"
+  end
+
+  test "API key with 'admin' scope can access any endpoint", %{admin_key: key} do
+    conn =
+      conn(:post, "/v1/analyze/batch")
+      |> put_req_header("authorization", "Bearer #{key}")
+      |> Auth.call(%{})
+
+    refute conn.status == 403
+  end
+
+  test "health endpoint requires no scope", %{no_scope_key: key} do
+    conn =
+      conn(:get, "/v1/health")
+      |> put_req_header("authorization", "Bearer #{key}")
+      |> Auth.call(%{})
+
+    refute conn.status == 403
+  end
+
+  test "JWT auth bypasses scope check" do
+    secret = Application.get_env(:lowendinsight, :jwt_secret, "lei_dev_secret")
+    signer = Joken.Signer.create("HS256", secret)
+    {:ok, jwt, _} = Joken.generate_and_sign(%{}, %{}, signer)
+
+    conn =
+      conn(:post, "/v1/analyze/batch")
+      |> put_req_header("authorization", "Bearer #{jwt}")
+      |> Auth.call(%{})
+
+    refute conn.status == 403
+    refute conn.halted
+  end
+end

--- a/test/lei/web/router_test.exs
+++ b/test/lei/web/router_test.exs
@@ -7,6 +7,7 @@ defmodule Lei.Web.RouterTest do
 
   setup do
     Lei.BatchCache.clear()
+    Lei.RateLimiter.clear()
 
     secret = Application.get_env(:lowendinsight, :jwt_secret, "lei_dev_secret")
     signer = Joken.Signer.create("HS256", secret)


### PR DESCRIPTION
## Summary
- Scope enforcement on API key auth (analyze, admin scopes; JWT bypasses)
- ETS-based sliding window rate limiter with tier-based limits (free: 60/min, pro: 600/min)
- Self-registration API: create orgs, generate/list/revoke API keys
- 4 new endpoints: POST/GET /v1/orgs, POST/GET/DELETE /v1/orgs/:slug/keys

## Test plan
- [x] 125 lei tests passing, 560 total, 0 failures
- [x] Scope enforcement: verify analyze scope required, admin scope grants all, JWT bypasses
- [x] Rate limiting: verify counter, blocking, tier differences, retry-after
- [x] Registration: create org, generate key, list keys, revoke key, 404 cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)