### PR TITLE
feat: health check and Prometheus metrics endpoints (#12, #13)

### DIFF
--- a/lib/lei/health.ex
+++ b/lib/lei/health.ex
@@ -1,0 +1,39 @@
+defmodule Lei.Health do
+  @moduledoc """
+  Health check functions for liveness and readiness probes.
+  """
+
+  @doc """
+  Liveness check — confirms the BEAM is running.
+  Always returns :ok unless the system is truly dead.
+  """
+  def liveness do
+    %{status: "ok"}
+  end
+
+  @doc """
+  Readiness check — verifies database connectivity.
+  Returns :ok or :degraded with per-check details.
+  """
+  def readiness do
+    checks = %{
+      database: check_database()
+    }
+
+    all_ok = Enum.all?(checks, fn {_k, v} -> v == "ok" end)
+
+    %{
+      status: if(all_ok, do: "ok", else: "degraded"),
+      checks: checks
+    }
+  end
+
+  defp check_database do
+    case Lei.Repo.query("SELECT 1") do
+      {:ok, _} -> "ok"
+      {:error, _} -> "error"
+    end
+  rescue
+    _ -> "error"
+  end
+end

--- a/lib/lei/metrics.ex
+++ b/lib/lei/metrics.ex
@@ -1,0 +1,69 @@
+defmodule Lei.Metrics do
+  @moduledoc """
+  Prometheus-compatible metrics endpoint.
+
+  Exposes BEAM VM metrics and application-specific counters
+  in Prometheus exposition format.
+  """
+
+  @doc """
+  Generate Prometheus exposition format text for all metrics.
+  """
+  def collect do
+    vm_metrics() ++ app_metrics()
+    |> Enum.join("\n")
+    |> Kernel.<>("\n")
+  end
+
+  defp vm_metrics do
+    memory = :erlang.memory()
+    {uptime_ms, _} = :erlang.statistics(:wall_clock)
+
+    [
+      "# HELP beam_memory_bytes BEAM memory usage in bytes",
+      "# TYPE beam_memory_bytes gauge",
+      "beam_memory_bytes{type=\"total\"} #{memory[:total]}",
+      "beam_memory_bytes{type=\"processes\"} #{memory[:processes]}",
+      "beam_memory_bytes{type=\"system\"} #{memory[:system]}",
+      "beam_memory_bytes{type=\"atom\"} #{memory[:atom]}",
+      "beam_memory_bytes{type=\"binary\"} #{memory[:binary]}",
+      "beam_memory_bytes{type=\"ets\"} #{memory[:ets]}",
+      "",
+      "# HELP beam_process_count Number of BEAM processes",
+      "# TYPE beam_process_count gauge",
+      "beam_process_count #{:erlang.system_info(:process_count)}",
+      "",
+      "# HELP beam_uptime_seconds BEAM uptime in seconds",
+      "# TYPE beam_uptime_seconds gauge",
+      "beam_uptime_seconds #{div(uptime_ms, 1000)}",
+      "",
+      "# HELP beam_scheduler_count Number of scheduler threads",
+      "# TYPE beam_scheduler_count gauge",
+      "beam_scheduler_count #{:erlang.system_info(:schedulers_online)}"
+    ]
+  end
+
+  defp app_metrics do
+    cache_stats = Lei.BatchCache.stats()
+
+    [
+      "",
+      "# HELP lei_cache_entries_total Total entries in batch cache",
+      "# TYPE lei_cache_entries_total gauge",
+      "lei_cache_entries_total #{cache_stats[:count] || 0}",
+      "",
+      "# HELP lei_cache_ecosystems Cache entries by ecosystem",
+      "# TYPE lei_cache_ecosystems gauge",
+      format_ecosystem_metrics(cache_stats[:ecosystems] || %{})
+    ]
+    |> List.flatten()
+  end
+
+  defp format_ecosystem_metrics(ecosystems) when map_size(ecosystems) == 0, do: []
+
+  defp format_ecosystem_metrics(ecosystems) do
+    Enum.map(ecosystems, fn {ecosystem, count} ->
+      "lei_cache_ecosystems{ecosystem=\"#{ecosystem}\"} #{count}"
+    end)
+  end
+end

--- a/lib/lei/web/router.ex
+++ b/lib/lei/web/router.ex
@@ -122,6 +122,33 @@ defmodule Lei.Web.Router do
     end
   end
 
+  # Unauthenticated health/metrics endpoints (outside /v1 prefix)
+
+  get "/healthz" do
+    data = Lei.Health.liveness()
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Poison.encode!(data))
+  end
+
+  get "/readyz" do
+    data = Lei.Health.readiness()
+    status = if data.status == "ok", do: 200, else: 503
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Poison.encode!(data))
+  end
+
+  get "/metrics" do
+    metrics = Lei.Metrics.collect()
+
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, metrics)
+  end
+
   match _ do
     conn
     |> put_resp_content_type("application/json")

--- a/test/lei/health_endpoints_test.exs
+++ b/test/lei/health_endpoints_test.exs
@@ -1,0 +1,60 @@
+defmodule Lei.HealthEndpointsTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+
+  @opts Lei.Web.Router.init([])
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Lei.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Lei.Repo, {:shared, self()})
+    :ok
+  end
+
+  test "GET /healthz returns 200 with ok status (no auth required)" do
+    conn =
+      conn(:get, "/healthz")
+      |> Lei.Web.Router.call(@opts)
+
+    assert conn.status == 200
+    body = Poison.decode!(conn.resp_body)
+    assert body["status"] == "ok"
+  end
+
+  test "GET /readyz returns 200 when database is healthy (no auth required)" do
+    conn =
+      conn(:get, "/readyz")
+      |> Lei.Web.Router.call(@opts)
+
+    assert conn.status == 200
+    body = Poison.decode!(conn.resp_body)
+    assert body["status"] == "ok"
+    assert body["checks"]["database"] == "ok"
+  end
+
+  test "GET /metrics returns prometheus text format (no auth required)" do
+    conn =
+      conn(:get, "/metrics")
+      |> Lei.Web.Router.call(@opts)
+
+    assert conn.status == 200
+
+    [content_type] = Plug.Conn.get_resp_header(conn, "content-type")
+    assert content_type =~ "text/plain"
+
+    assert conn.resp_body =~ "beam_memory_bytes"
+    assert conn.resp_body =~ "beam_process_count"
+    assert conn.resp_body =~ "lei_cache_entries_total"
+  end
+
+  test "health endpoints do not require authentication" do
+    # No auth header — should still work (not /v1 prefix)
+    for path <- ["/healthz", "/readyz", "/metrics"] do
+      conn =
+        conn(:get, path)
+        |> Lei.Web.Router.call(@opts)
+
+      assert conn.status in [200, 503], "#{path} returned #{conn.status}"
+      refute conn.halted
+    end
+  end
+end

--- a/test/lei/health_test.exs
+++ b/test/lei/health_test.exs
@@ -1,0 +1,26 @@
+defmodule Lei.HealthTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Lei.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Lei.Repo, {:shared, self()})
+    :ok
+  end
+
+  test "liveness returns ok" do
+    result = Lei.Health.liveness()
+    assert result.status == "ok"
+  end
+
+  test "readiness checks database" do
+    result = Lei.Health.readiness()
+    assert result.status in ["ok", "degraded"]
+    assert Map.has_key?(result.checks, :database)
+  end
+
+  test "readiness returns ok when database is available" do
+    result = Lei.Health.readiness()
+    assert result.status == "ok"
+    assert result.checks.database == "ok"
+  end
+end

--- a/test/lei/metrics_test.exs
+++ b/test/lei/metrics_test.exs
@@ -1,0 +1,33 @@
+defmodule Lei.MetricsTest do
+  use ExUnit.Case, async: true
+
+  test "collect returns prometheus format text" do
+    output = Lei.Metrics.collect()
+    assert is_binary(output)
+    assert output =~ "beam_memory_bytes"
+    assert output =~ "beam_process_count"
+    assert output =~ "beam_uptime_seconds"
+    assert output =~ "beam_scheduler_count"
+    assert output =~ "lei_cache_entries_total"
+  end
+
+  test "includes TYPE and HELP annotations" do
+    output = Lei.Metrics.collect()
+    assert output =~ "# HELP beam_memory_bytes"
+    assert output =~ "# TYPE beam_memory_bytes gauge"
+    assert output =~ "# TYPE beam_process_count gauge"
+  end
+
+  test "memory metrics have type labels" do
+    output = Lei.Metrics.collect()
+    assert output =~ ~r/beam_memory_bytes\{type="total"\} \d+/
+    assert output =~ ~r/beam_memory_bytes\{type="processes"\} \d+/
+    assert output =~ ~r/beam_memory_bytes\{type="system"\} \d+/
+  end
+
+  test "process count is a positive integer" do
+    output = Lei.Metrics.collect()
+    [_, count] = Regex.run(~r/beam_process_count (\d+)/, output)
+    assert String.to_integer(count) > 0
+  end
+end


### PR DESCRIPTION
## Summary
- `GET /healthz` — liveness probe (BEAM alive)
- `GET /readyz` — readiness probe (checks DB connectivity, returns 503 when unavailable)
- `GET /metrics` — Prometheus exposition format (BEAM memory, processes, uptime, schedulers, cache stats)
- All unauthenticated (outside /v1 prefix), ready for Kubernetes probes and UDS Core Prometheus

Closes #12, Closes #13

## Test plan
- [x] 11 new tests, 547 total, 0 failures
- [x] Liveness always returns 200 ok
- [x] Readiness checks database connectivity
- [x] Metrics output in valid Prometheus format
- [x] No auth required for any health endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)