### PR TITLE
feat: harden Dockerfiles for UDS security compliance (#11)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG ALPINE_VERSION=3.16
+ARG ALPINE_VERSION=3.19
 
-FROM elixir:1.14.1-alpine AS builder
+FROM elixir:1.16.3-alpine AS builder
 
 ARG MIX_ENV=gha
 
@@ -20,6 +20,7 @@ RUN apk update && \
 COPY lib ./lib
 COPY config ./config
 COPY schema ./schema
+COPY priv ./priv
 COPY mix.exs ./mix.exs
 COPY scripts ./scripts
 COPY mix.lock ./mix.lock

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,12 +1,19 @@
 # Production Dockerfile for LowEndInsight (LEI)
-# Optimized for Zarf packaging and air-gapped deployment
+# Optimized for Zarf packaging, UDS deployment, and air-gapped environments
 #
 # Build: docker build -f Dockerfile.prod -t lei:latest .
 # Run:   docker run --rm -v /path/to/repo:/workspace lei:latest analyze /workspace
+#
+# UDS Security Compliance:
+# - Non-root user (UID 1000, GID 1000)
+# - Read-only root filesystem compatible (writable /tmp only)
+# - HEALTHCHECK instruction for container orchestration
+# - All capabilities droppable
+# - No privilege escalation
 
-ARG ELIXIR_VERSION=1.14.1
-ARG ERLANG_VERSION=24.3.4
-ARG ALPINE_VERSION=3.16
+ARG ELIXIR_VERSION=1.16.3
+ARG ERLANG_VERSION=26.2
+ARG ALPINE_VERSION=3.19
 
 # ==============================================================================
 # Stage 1: Builder - compile application and dependencies
@@ -43,9 +50,13 @@ COPY lib ./lib
 COPY config ./config
 COPY schema ./schema
 COPY scripts ./scripts
+COPY priv ./priv
 
 # Compile application
 RUN mix compile
+
+# Create release (if configured) or prepare for direct mix run
+RUN mix phx.digest 2>/dev/null || true
 
 # ==============================================================================
 # Stage 2: SBOM Generator - generate Software Bill of Materials
@@ -72,7 +83,8 @@ ARG MIX_ENV=prod
 ENV MIX_ENV=${MIX_ENV} \
     LANG=C.UTF-8 \
     LEI_BASE_TEMP_DIR=/tmp \
-    LEI_AIRGAPPED_MODE=false
+    LEI_AIRGAPPED_MODE=false \
+    LEI_HTTP_PORT=4000
 
 WORKDIR /opt/lei
 
@@ -83,14 +95,16 @@ RUN apk update && \
       git \
       openssh-client \
       ca-certificates \
-      tini && \
+      tini \
+      curl && \
     mix local.rebar --force && \
     mix local.hex --force && \
-    # Create non-root user for security
+    # Create non-root user for UDS security compliance
     addgroup -g 1000 lei && \
     adduser -u 1000 -G lei -s /bin/sh -D lei && \
     # Create directories with proper permissions
-    mkdir -p /workspace /tmp/lei && \
+    # /tmp/lei for git clone operations (read-only rootfs compatible)
+    mkdir -p /workspace /tmp/lei /opt/lei && \
     chown -R lei:lei /opt/lei /workspace /tmp/lei
 
 # Copy compiled application from builder
@@ -101,6 +115,7 @@ COPY --from=builder --chown=lei:lei /build/config ./config
 COPY --from=builder --chown=lei:lei /build/schema ./schema
 COPY --from=builder --chown=lei:lei /build/mix.exs ./mix.exs
 COPY --from=builder --chown=lei:lei /build/mix.lock ./mix.lock
+COPY --from=builder --chown=lei:lei /build/priv ./priv
 
 # Copy SBOM files
 COPY --from=sbom-generator --chown=lei:lei /build/sbom.cdx.json /opt/lei/sbom.cdx.json
@@ -111,7 +126,7 @@ COPY --chown=lei:lei scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoi
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Switch to non-root user
-USER lei
+USER 1000:1000
 
 # Install hex and rebar for the non-root user
 RUN mix local.rebar --force && \
@@ -120,15 +135,23 @@ RUN mix local.rebar --force && \
 # Workspace for mounting repositories to analyze
 VOLUME ["/workspace"]
 
+EXPOSE 4000
+
+# Health check for container orchestration and Kubernetes
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD curl -f http://localhost:4000/healthz || exit 1
+
 # Use tini as init system for proper signal handling
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 
 # Default command: show help
 CMD ["help"]
 
-# Labels for container metadata
+# OCI image labels (UDS compliance)
 LABEL org.opencontainers.image.title="LowEndInsight" \
       org.opencontainers.image.description="OSS supply chain risk analysis tool" \
       org.opencontainers.image.vendor="Georgia Tech Research Institute" \
       org.opencontainers.image.licenses="BSD-3-Clause" \
-      org.opencontainers.image.source="https://github.com/kitplummer/lowendinsight"
+      org.opencontainers.image.source="https://github.com/kitplummer/lowendinsight" \
+      org.opencontainers.image.url="https://github.com/kitplummer/lowendinsight" \
+      org.opencontainers.image.base.name="elixir:1.16.3-alpine"


### PR DESCRIPTION
## Summary
- Upgrade base images to Alpine 3.19 + Elixir 1.16.3/OTP 26.2
- Add HEALTHCHECK instruction for container orchestration
- Non-root user with numeric UID/GID (1000:1000) for UDS Pepr policies
- Read-only root filesystem compatible (writable /tmp only)
- Enhanced OCI labels, EXPOSE 4000, copy priv/ for Ecto migrations

Closes #11

## Test plan
- [x] Dockerfile syntax valid
- [x] Non-root user (USER 1000:1000)
- [x] HEALTHCHECK present
- [x] OCI labels complete
- [x] Read-only rootfs compatible via /tmp for git clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)