### PR TITLE
feat(test): UDS journey and upgrade test scripts (#16, #17)

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -71,15 +71,22 @@ tasks:
         description: "Validate LEI deployment"
 
   - name: journey-test
-    description: "Run full journey tests"
+    description: "Full journey: build + deploy + validate + cleanup"
     actions:
-      - cmd: tests/journey.sh
+      - task: dev
+      - cmd: bash tests/journey.sh
         description: "Execute journey test suite"
+      - task: remove
+
+  - name: journey-test-only
+    description: "Run journey tests against an existing deployment"
+    actions:
+      - cmd: bash tests/journey.sh
 
   - name: upgrade-test
-    description: "Run upgrade tests"
+    description: "Run upgrade tests (requires two bundle files)"
     actions:
-      - cmd: tests/upgrade.sh
+      - cmd: bash tests/upgrade.sh
         description: "Execute upgrade test suite"
 
   # ---------- Utility Tasks ----------

--- a/tests/journey.sh
+++ b/tests/journey.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Journey test for LEI UDS deployment
+# Validates the complete deployment lifecycle per UDS package requirements.
+# Usage: ./tests/journey.sh
+# Environment: UDS_DOMAIN (default: uds.dev)
+set -euo pipefail
+
+DOMAIN="${UDS_DOMAIN:-uds.dev}"
+NAMESPACE="${LEI_NAMESPACE:-lei}"
+TIMEOUT="${WAIT_TIMEOUT:-300s}"
+API_URL="https://lei.${DOMAIN}"
+
+PASSED=0
+FAILED=0
+WARNINGS=0
+
+pass() { echo "  PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "  FAIL: $1"; FAILED=$((FAILED + 1)); }
+warn() { echo "  WARN: $1"; WARNINGS=$((WARNINGS + 1)); }
+
+cleanup() {
+  echo ""
+  echo "=== Results: ${PASSED} passed, ${FAILED} failed, ${WARNINGS} warnings ==="
+  if [ "$FAILED" -gt 0 ]; then
+    echo "JOURNEY TEST FAILED"
+    exit 1
+  fi
+  echo "JOURNEY TEST PASSED"
+}
+trap cleanup EXIT
+
+echo "=== LEI UDS Journey Test ==="
+echo "Domain: ${DOMAIN}"
+echo "Namespace: ${NAMESPACE}"
+echo ""
+
+# --- 1. Pod readiness ---
+echo "[1/7] Pod status"
+if kubectl wait --for=condition=ready pod \
+    -l app.kubernetes.io/name=lowendinsight \
+    -n "${NAMESPACE}" --timeout="${TIMEOUT}" 2>/dev/null; then
+  pass "LEI pods are ready"
+else
+  fail "LEI pods did not become ready within ${TIMEOUT}"
+fi
+
+# --- 2. UDS Package CR ---
+echo "[2/7] UDS Package CR"
+PHASE=$(kubectl get package lei -n "${NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+if [ "${PHASE}" = "Ready" ]; then
+  pass "UDS Package CR phase is Ready"
+elif [ -n "${PHASE}" ]; then
+  fail "UDS Package CR phase is '${PHASE}', expected 'Ready'"
+else
+  warn "UDS Package CR not found (may not be using UDS operator)"
+fi
+
+# --- 3. Istio VirtualService ---
+echo "[3/7] Istio networking"
+VS_HOST=$(kubectl get virtualservice -n "${NAMESPACE}" \
+    -o jsonpath='{.items[0].spec.hosts[0]}' 2>/dev/null || echo "")
+if echo "${VS_HOST}" | grep -q "lei"; then
+  pass "VirtualService routes to lei host: ${VS_HOST}"
+else
+  warn "No VirtualService found for lei (Istio may not be configured)"
+fi
+
+# --- 4. NetworkPolicies ---
+echo "[4/7] Network policies"
+NP_COUNT=$(kubectl get networkpolicy -n "${NAMESPACE}" --no-headers 2>/dev/null | wc -l)
+if [ "${NP_COUNT}" -gt 0 ]; then
+  pass "Found ${NP_COUNT} network policies"
+else
+  warn "No network policies found in namespace ${NAMESPACE}"
+fi
+
+# --- 5. SSO / Keycloak ---
+echo "[5/7] SSO configuration"
+if kubectl get secret -n "${NAMESPACE}" 2>/dev/null | grep -q "sso"; then
+  pass "SSO secret found"
+else
+  warn "SSO secret not found (Keycloak client may not be provisioned)"
+fi
+
+# --- 6. ServiceMonitor ---
+echo "[6/7] Monitoring"
+if kubectl get servicemonitor -n "${NAMESPACE}" --no-headers 2>/dev/null | grep -q "lei"; then
+  pass "ServiceMonitor found for LEI"
+else
+  warn "No ServiceMonitor found (Prometheus operator may not be installed)"
+fi
+
+# --- 7. API functional tests ---
+echo "[7/7] API functional tests"
+
+# Health check
+if curl -sf "${API_URL}/healthz" | jq -e '.status == "ok"' >/dev/null 2>&1; then
+  pass "GET /healthz returns ok"
+else
+  fail "GET /healthz failed"
+fi
+
+# Readiness
+if curl -sf "${API_URL}/readyz" | jq -e '.status == "ready"' >/dev/null 2>&1; then
+  pass "GET /readyz returns ready"
+else
+  fail "GET /readyz failed"
+fi
+
+# Metrics
+if curl -sf "${API_URL}/metrics" | grep -q "beam_"; then
+  pass "GET /metrics returns BEAM metrics"
+else
+  fail "GET /metrics failed or missing BEAM metrics"
+fi
+
+# Health with cache stats
+if curl -sf "${API_URL}/v1/health" -H "Authorization: Bearer ${LEI_JWT:-}" 2>/dev/null | jq -e '.cache' >/dev/null 2>&1; then
+  pass "GET /v1/health returns cache stats"
+else
+  warn "GET /v1/health not accessible (auth may be required)"
+fi

--- a/tests/upgrade.sh
+++ b/tests/upgrade.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Upgrade test for LEI UDS bundle
+# Validates deploying version N+1 over version N without data loss.
+# Usage: ./tests/upgrade.sh <previous-bundle> <current-bundle>
+# Environment: UDS_DOMAIN (default: uds.dev)
+set -euo pipefail
+
+PREVIOUS_BUNDLE="${1:?Usage: upgrade.sh <previous-bundle.tar.zst> <current-bundle.tar.zst>}"
+CURRENT_BUNDLE="${2:?Usage: upgrade.sh <previous-bundle.tar.zst> <current-bundle.tar.zst>}"
+DOMAIN="${UDS_DOMAIN:-uds.dev}"
+NAMESPACE="${LEI_NAMESPACE:-lei}"
+TIMEOUT="${WAIT_TIMEOUT:-300s}"
+API_URL="https://lei.${DOMAIN}"
+
+PASSED=0
+FAILED=0
+
+pass() { echo "  PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "  FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+cleanup() {
+  echo ""
+  echo "=== Results: ${PASSED} passed, ${FAILED} failed ==="
+  if [ "$FAILED" -gt 0 ]; then
+    echo "UPGRADE TEST FAILED"
+    exit 1
+  fi
+  echo "UPGRADE TEST PASSED"
+}
+trap cleanup EXIT
+
+echo "=== LEI UDS Upgrade Test ==="
+echo "Previous: ${PREVIOUS_BUNDLE}"
+echo "Current:  ${CURRENT_BUNDLE}"
+echo "Domain:   ${DOMAIN}"
+echo ""
+
+# --- 1. Deploy previous version ---
+echo "[1/6] Deploying previous version..."
+if [ ! -f "${PREVIOUS_BUNDLE}" ]; then
+  fail "Previous bundle not found: ${PREVIOUS_BUNDLE}"
+  exit 1
+fi
+
+uds deploy "${PREVIOUS_BUNDLE}" --confirm --config uds-config.yaml
+if kubectl wait --for=condition=ready pod \
+    -l app.kubernetes.io/name=lowendinsight \
+    -n "${NAMESPACE}" --timeout="${TIMEOUT}" 2>/dev/null; then
+  pass "Previous version deployed and pods ready"
+else
+  fail "Previous version pods did not become ready"
+  exit 1
+fi
+
+# --- 2. Verify previous version is functional ---
+echo "[2/6] Verifying previous version..."
+if curl -sf "${API_URL}/healthz" | jq -e '.status == "ok"' >/dev/null 2>&1; then
+  pass "Previous version health check passed"
+else
+  fail "Previous version health check failed"
+fi
+
+# --- 3. Seed test data ---
+echo "[3/6] Seeding test data..."
+PRE_CACHE=""
+
+# Try batch analyze endpoint
+SEED_RESPONSE=$(curl -sf -X POST "${API_URL}/v1/analyze/batch" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${LEI_JWT:-}" \
+  -d '{
+    "dependencies": [
+      {"ecosystem": "hex", "package": "jason", "version": "1.4.0"}
+    ]
+  }' 2>/dev/null || echo "")
+
+if [ -n "${SEED_RESPONSE}" ]; then
+  pass "Seeded test data via batch analyze"
+  sleep 5
+else
+  echo "  INFO: Could not seed via batch (auth may be required), continuing..."
+fi
+
+# Record pre-upgrade state
+PRE_CACHE=$(curl -sf "${API_URL}/v1/health" \
+  -H "Authorization: Bearer ${LEI_JWT:-}" 2>/dev/null | \
+  jq -r '.cache.size // empty' 2>/dev/null || echo "")
+
+if [ -n "${PRE_CACHE}" ]; then
+  echo "  Pre-upgrade cache size: ${PRE_CACHE}"
+else
+  echo "  INFO: Could not read cache stats, will skip preservation check"
+fi
+
+# --- 4. Deploy current version (upgrade) ---
+echo "[4/6] Deploying current version (upgrade)..."
+if [ ! -f "${CURRENT_BUNDLE}" ]; then
+  fail "Current bundle not found: ${CURRENT_BUNDLE}"
+  exit 1
+fi
+
+UPGRADE_START=$(date +%s)
+uds deploy "${CURRENT_BUNDLE}" --confirm --config uds-config.yaml
+
+if kubectl wait --for=condition=ready pod \
+    -l app.kubernetes.io/name=lowendinsight \
+    -n "${NAMESPACE}" --timeout="${TIMEOUT}" 2>/dev/null; then
+  UPGRADE_END=$(date +%s)
+  UPGRADE_DURATION=$((UPGRADE_END - UPGRADE_START))
+  pass "Upgrade completed in ${UPGRADE_DURATION}s, pods ready"
+
+  # Check upgrade time is reasonable (< 5 min)
+  if [ "${UPGRADE_DURATION}" -lt 300 ]; then
+    pass "Upgrade completed within 5 minute window"
+  else
+    fail "Upgrade took ${UPGRADE_DURATION}s, exceeds 5 minute target"
+  fi
+else
+  fail "Upgraded pods did not become ready within ${TIMEOUT}"
+fi
+
+# --- 5. Verify post-upgrade functionality ---
+echo "[5/6] Verifying post-upgrade functionality..."
+
+# Health check
+if curl -sf "${API_URL}/healthz" | jq -e '.status == "ok"' >/dev/null 2>&1; then
+  pass "Post-upgrade health check passed"
+else
+  fail "Post-upgrade health check failed"
+fi
+
+# Readiness
+if curl -sf "${API_URL}/readyz" | jq -e '.status == "ready"' >/dev/null 2>&1; then
+  pass "Post-upgrade readiness check passed"
+else
+  fail "Post-upgrade readiness check failed"
+fi
+
+# Metrics
+if curl -sf "${API_URL}/metrics" | grep -q "beam_" 2>/dev/null; then
+  pass "Post-upgrade metrics endpoint working"
+else
+  fail "Post-upgrade metrics endpoint failed"
+fi
+
+# --- 6. Verify data preservation ---
+echo "[6/6] Verifying data preservation..."
+
+if [ -n "${PRE_CACHE}" ]; then
+  POST_CACHE=$(curl -sf "${API_URL}/v1/health" \
+    -H "Authorization: Bearer ${LEI_JWT:-}" 2>/dev/null | \
+    jq -r '.cache.size // "0"' 2>/dev/null || echo "0")
+
+  echo "  Post-upgrade cache size: ${POST_CACHE}"
+
+  if [ "${POST_CACHE}" -ge "${PRE_CACHE}" ] 2>/dev/null; then
+    pass "Cache data preserved across upgrade (${PRE_CACHE} -> ${POST_CACHE})"
+  else
+    fail "Cache data lost during upgrade (${PRE_CACHE} -> ${POST_CACHE})"
+  fi
+else
+  echo "  INFO: Skipping cache preservation check (no pre-upgrade data)"
+fi
+
+# Check database migration state
+if kubectl exec -n "${NAMESPACE}" \
+    "$(kubectl get pod -n "${NAMESPACE}" -l app.kubernetes.io/name=lowendinsight -o jsonpath='{.items[0].metadata.name}')" \
+    -- bin/lei eval "Lei.Repo.__adapter__()" >/dev/null 2>&1; then
+  pass "Database adapter accessible post-upgrade"
+else
+  echo "  INFO: Could not verify database directly"
+fi


### PR DESCRIPTION
## Summary

- Add `tests/journey.sh` — full UDS deployment lifecycle validation (7 checks: pods, Package CR, VirtualService, NetworkPolicies, SSO, ServiceMonitor, API)
- Add `tests/upgrade.sh` — version N→N+1 upgrade with data preservation and timing verification
- Update `tasks.yaml` to wire `journey-test` (full lifecycle: build → deploy → test → cleanup), `journey-test-only` (against existing deployment), and `upgrade-test` tasks

Closes #16, closes #17.

## Test plan

- [ ] `uds run journey-test` validates full lifecycle on local k3d cluster
- [ ] `uds run journey-test-only` validates against an existing deployment
- [ ] `uds run upgrade-test` validates version N→N+1 with data preservation
- [ ] Scripts exit non-zero on failure with clear error messages
- [ ] Cleanup runs even on test failure (trap EXIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)