### PR TITLE
feat: auth UI + agentic contribution detection

### DIFF
--- a/apps/lowendinsight/lib/analyzer_module.ex
+++ b/apps/lowendinsight/lib/analyzer_module.ex
@@ -123,6 +123,25 @@ defmodule AnalyzerModule do
 
       {:ok, top10_contributors} = GitModule.get_top10_contributors_map(repo)
 
+      # Agentic detection: classify contributors and compute ratio
+      {:ok, contributors} = GitModule.get_contributors(repo)
+      {:ok, commit_trailers} = GitModule.get_commits_with_trailers(repo)
+
+      contributors_with_messages =
+        Enum.map(contributors, fn contributor ->
+          messages =
+            commit_trailers
+            |> Enum.filter(&(&1.author_email == contributor.email))
+            |> Enum.map(& &1.body)
+
+          {contributor, messages}
+        end)
+
+      agentic_analysis =
+        Lei.AgenticDetector.analyze(contributors_with_messages, num_filtered_contributors)
+
+      {:ok, agentic_risk} = RiskLogic.agentic_risk(agentic_analysis.agentic_contribution_ratio)
+
       project_types_identified =
         case Map.has_key?(options, :types) && options.types == true do
           true ->
@@ -183,7 +202,12 @@ defmodule AnalyzerModule do
             functional_contributors: num_filtered_contributors,
             functional_contributor_names: functional_contributors,
             top10_contributors: top10_contributors,
-            sbom_risk: sbom_risk
+            sbom_risk: sbom_risk,
+            agentic_risk: agentic_risk,
+            agentic_contribution_ratio: agentic_analysis.agentic_contribution_ratio,
+            human_contributor_count: agentic_analysis.human_contributor_count,
+            human_functional_contributors: agentic_analysis.human_functional_contributors,
+            agentic_contributors: agentic_analysis.classified_contributors
           }
         }
       }

--- a/apps/lowendinsight/lib/contributor.ex
+++ b/apps/lowendinsight/lib/contributor.ex
@@ -4,7 +4,8 @@ defmodule Contributor do
             count: 0,
             merges: 0,
             last_contribution_date: "",
-            commits: []
+            commits: [],
+            classification: :unknown
 
   @type t :: %__MODULE__{
           name: String.t(),
@@ -12,6 +13,7 @@ defmodule Contributor do
           count: integer,
           merges: integer,
           last_contribution_date: String.t(),
-          commits: [String.t()]
+          commits: [String.t()],
+          classification: :human | :bot | :agent | :unknown
         }
 end

--- a/apps/lowendinsight/lib/git_module.ex
+++ b/apps/lowendinsight/lib/git_module.ex
@@ -355,6 +355,33 @@ defmodule GitModule do
     author_date
   end
 
+  @doc """
+  get_commits_with_trailers/1: returns a list of maps with author_email and body
+  for all commits. Used for detecting AI co-author trailers.
+  """
+  @spec get_commits_with_trailers(Git.Repository.t()) :: {:ok, [map()]}
+  def get_commits_with_trailers(repo) do
+    separator = "---LEI_SEPARATOR---"
+
+    raw =
+      Git.log!(repo, ["--pretty=format:%ae\t%B#{separator}"])
+      |> String.split(separator)
+      |> Enum.map(&String.trim/1)
+      |> Enum.filter(&(&1 != ""))
+
+    commits =
+      Enum.map(raw, fn entry ->
+        case String.split(entry, "\t", parts: 2) do
+          [email, body] -> %{author_email: email, body: body}
+          [email] -> %{author_email: email, body: ""}
+          _ -> nil
+        end
+      end)
+      |> Enum.filter(&(not is_nil(&1)))
+
+    {:ok, commits}
+  end
+
   @spec get_repo_size(Git.Repository.t()) :: {:ok, String.t()}
   def get_repo_size(repo) do
     space =

--- a/apps/lowendinsight/lib/lei/agentic_detector.ex
+++ b/apps/lowendinsight/lib/lei/agentic_detector.ex
@@ -1,0 +1,143 @@
+defmodule Lei.AgenticDetector do
+  @moduledoc """
+  Classifies contributors as human, bot, or AI-assisted (agent)
+  based on email/name patterns and commit message trailers.
+  """
+
+  @bot_email_patterns [
+    ~r/\[bot\]@users\.noreply\.github\.com$/i,
+    ~r/^dependabot@/i,
+    ~r/^renovate@/i,
+    ~r/^greenkeeper@/i,
+    ~r/^snyk-bot@/i,
+    ~r/^github-actions@/i,
+    ~r/^mergify@/i,
+    ~r/^imgbot@/i,
+    ~r/^semantic-release-bot@/i,
+    ~r/^release-please@/i
+  ]
+
+  @bot_name_patterns [
+    ~r/\[bot\]$/i,
+    ~r/^dependabot$/i,
+    ~r/^renovate$/i,
+    ~r/^github-actions$/i,
+    ~r/^mergify$/i,
+    ~r/^imgbot$/i,
+    ~r/^semantic-release-bot$/i,
+    ~r/^release-please$/i
+  ]
+
+  @ai_coauthor_patterns [
+    ~r/Co-Authored-By:.*Claude/i,
+    ~r/Co-Authored-By:.*@anthropic\.com/i,
+    ~r/Co-Authored-By:.*Copilot/i,
+    ~r/Co-Authored-By:.*Cursor/i,
+    ~r/Co-Authored-By:.*Windsurf/i,
+    ~r/Co-Authored-By:.*Devin/i
+  ]
+
+  @doc """
+  Classifies a contributor as `:human` or `:bot` based on name/email patterns.
+  """
+  @spec classify_contributor(String.t(), String.t()) :: :human | :bot
+  def classify_contributor(name, email) do
+    if bot_by_email?(email) or bot_by_name?(name) do
+      :bot
+    else
+      :human
+    end
+  end
+
+  @doc """
+  Detects AI co-author trailers in commit messages.
+  Returns a deduplicated list of matched AI tool names.
+  """
+  @spec detect_ai_coauthors([String.t()]) :: [String.t()]
+  def detect_ai_coauthors(commit_messages) do
+    commit_messages
+    |> Enum.flat_map(&extract_ai_coauthors/1)
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Analyzes a list of contributors with their commit messages.
+
+  Expects a list of `{contributor, commit_messages}` tuples where
+  contributor is a map/struct with `:name`, `:email`, `:count` fields,
+  and commit_messages is a list of commit body strings.
+
+  Returns analysis summary with classified contributors and metrics.
+  """
+  @spec analyze([{map(), [String.t()]}], non_neg_integer()) :: map()
+  def analyze(contributors_with_messages, functional_count) do
+    classified =
+      Enum.map(contributors_with_messages, fn {contributor, messages} ->
+        base_class = classify_contributor(contributor.name, contributor.email)
+        ai_coauthors = detect_ai_coauthors(messages)
+
+        classification =
+          case {base_class, ai_coauthors} do
+            {:bot, _} -> :bot
+            {:human, [_ | _]} -> :agent
+            {:human, []} -> :human
+          end
+
+        %{
+          name: contributor.name,
+          email: contributor.email,
+          commit_count: contributor.count,
+          classification: classification,
+          ai_coauthors: ai_coauthors
+        }
+      end)
+
+    human_contributors = Enum.filter(classified, &(&1.classification == :human))
+    bot_contributors = Enum.filter(classified, &(&1.classification == :bot))
+    agent_contributors = Enum.filter(classified, &(&1.classification == :agent))
+
+    total_commits = Enum.reduce(classified, 0, fn c, acc -> acc + c.commit_count end)
+
+    non_human_commits =
+      classified
+      |> Enum.filter(&(&1.classification in [:bot, :agent]))
+      |> Enum.reduce(0, fn c, acc -> acc + c.commit_count end)
+
+    ratio = if total_commits > 0, do: Float.round(non_human_commits / total_commits, 4), else: 0.0
+
+    human_functional =
+      if functional_count > 0 do
+        max(0, functional_count - length(bot_contributors))
+      else
+        length(human_contributors)
+      end
+
+    %{
+      classified_contributors: classified,
+      agentic_contribution_ratio: ratio,
+      human_contributor_count: length(human_contributors),
+      human_functional_contributors: human_functional,
+      bot_contributors: Enum.map(bot_contributors, & &1.name),
+      agent_contributors: Enum.map(agent_contributors, & &1.name)
+    }
+  end
+
+  defp bot_by_email?(email) do
+    Enum.any?(@bot_email_patterns, &Regex.match?(&1, email))
+  end
+
+  defp bot_by_name?(name) do
+    Enum.any?(@bot_name_patterns, &Regex.match?(&1, name))
+  end
+
+  defp extract_ai_coauthors(message) do
+    @ai_coauthor_patterns
+    |> Enum.filter(&Regex.match?(&1, message))
+    |> Enum.map(fn pattern ->
+      case Regex.run(~r/Co-Authored-By:\s*(.+)/i, message) do
+        [_, match] -> String.trim(match)
+        _ -> Regex.source(pattern)
+      end
+    end)
+  end
+end

--- a/apps/lowendinsight/lib/lei/api_key.ex
+++ b/apps/lowendinsight/lib/lei/api_key.ex
@@ -3,13 +3,13 @@ defmodule Lei.ApiKey do
   import Ecto.Changeset
 
   schema "api_keys" do
-    field :name, :string
-    field :key_hash, :string
-    field :key_prefix, :string
-    field :scopes, {:array, :string}, default: []
-    field :active, :boolean, default: true
-    field :last_used_at, :utc_datetime_usec
-    belongs_to :org, Lei.Org
+    field(:name, :string)
+    field(:key_hash, :string)
+    field(:key_prefix, :string)
+    field(:scopes, {:array, :string}, default: [])
+    field(:active, :boolean, default: true)
+    field(:last_used_at, :utc_datetime_usec)
+    belongs_to(:org, Lei.Org)
     timestamps()
   end
 

--- a/apps/lowendinsight/lib/lei/api_keys.ex
+++ b/apps/lowendinsight/lib/lei/api_keys.ex
@@ -50,7 +50,7 @@ defmodule Lei.ApiKeys do
     key_hash = hash_key(raw_key)
 
     case Repo.one(
-           from k in ApiKey, where: k.key_hash == ^key_hash and k.active == true, preload: :org
+           from(k in ApiKey, where: k.key_hash == ^key_hash and k.active == true, preload: :org)
          ) do
       nil -> {:error, :invalid_key}
       api_key -> {:ok, api_key}
@@ -66,7 +66,7 @@ defmodule Lei.ApiKeys do
   end
 
   def list_keys(%Org{} = org) do
-    Repo.all(from k in ApiKey, where: k.org_id == ^org.id, order_by: [desc: :inserted_at])
+    Repo.all(from(k in ApiKey, where: k.org_id == ^org.id, order_by: [desc: :inserted_at]))
   end
 
   def revoke_key(key_id) do

--- a/apps/lowendinsight/lib/lei/auth.ex
+++ b/apps/lowendinsight/lib/lei/auth.ex
@@ -102,7 +102,10 @@ defmodule Lei.Auth do
           conn
           |> put_resp_header("retry-after", to_string(retry_secs))
           |> put_resp_content_type("application/json")
-          |> send_resp(429, Poison.encode!(%{error: "rate limit exceeded", retry_after: retry_secs}))
+          |> send_resp(
+            429,
+            Poison.encode!(%{error: "rate limit exceeded", retry_after: retry_secs})
+          )
           |> halt()
       end
     else

--- a/apps/lowendinsight/lib/lei/metrics.ex
+++ b/apps/lowendinsight/lib/lei/metrics.ex
@@ -4,7 +4,7 @@ defmodule Lei.Metrics do
   """
 
   def collect do
-    vm_metrics() ++ app_metrics()
+    (vm_metrics() ++ app_metrics())
     |> Enum.join("\n")
     |> Kernel.<>("\n")
   end

--- a/apps/lowendinsight/lib/lei/org.ex
+++ b/apps/lowendinsight/lib/lei/org.ex
@@ -3,10 +3,10 @@ defmodule Lei.Org do
   import Ecto.Changeset
 
   schema "orgs" do
-    field :name, :string
-    field :slug, :string
-    field :tier, :string, default: "free"
-    has_many :api_keys, Lei.ApiKey
+    field(:name, :string)
+    field(:slug, :string)
+    field(:tier, :string, default: "free")
+    has_many(:api_keys, Lei.ApiKey)
     timestamps()
   end
 

--- a/apps/lowendinsight/lib/lei/web/router.ex
+++ b/apps/lowendinsight/lib/lei/web/router.ex
@@ -1,17 +1,173 @@
 defmodule Lei.Web.Router do
   @moduledoc """
-  HTTP router for LEI batch analysis API.
+  HTTP router for LEI batch analysis API and web UI.
 
   Provides the POST /v1/analyze/batch endpoint for analyzing
-  lists of dependencies with parallel cache lookups.
+  lists of dependencies with parallel cache lookups, plus
+  HTML signup/login/dashboard routes.
   """
   use Plug.Router
 
-  plug Plug.Logger
-  plug Plug.Parsers, parsers: [:json], json_decoder: Poison
-  plug Lei.Auth
-  plug :match
-  plug :dispatch
+  @templates_dir Path.expand("../../../priv/templates", __DIR__)
+
+  plug(Plug.Logger)
+
+  plug(:put_secret_key_base)
+
+  plug(Plug.Session,
+    store: :cookie,
+    key: "_lei_session",
+    signing_salt: "lei_auth"
+  )
+
+  plug(Plug.Static,
+    at: "/static",
+    from: Path.expand("../../../priv/static", __DIR__)
+  )
+
+  plug(Plug.Parsers, parsers: [:urlencoded, :json], json_decoder: Poison)
+  plug(Lei.Auth)
+  plug(:match)
+  plug(:dispatch)
+
+  # --- HTML UI routes ---
+
+  get "/signup" do
+    render_page(conn, "signup.html.eex")
+  end
+
+  post "/signup" do
+    name = conn.body_params["name"]
+
+    if is_nil(name) or name == "" do
+      render_page(conn, "signup.html.eex", flash_error: "Organization name is required.")
+    else
+      case Lei.ApiKeys.find_or_create_org(name) do
+        {:ok, org} ->
+          case Lei.ApiKeys.create_api_key(org, "admin", ["admin", "analyze"]) do
+            {:ok, raw_key, _api_key} ->
+              render_page(conn, "signup_success.html.eex", org_name: org.name, raw_key: raw_key)
+
+            {:error, _changeset} ->
+              render_page(conn, "signup.html.eex",
+                flash_error: "Failed to create API key. Please try again."
+              )
+          end
+
+        {:error, _changeset} ->
+          render_page(conn, "signup.html.eex",
+            flash_error: "Failed to create organization. Please try again."
+          )
+      end
+    end
+  end
+
+  get "/login" do
+    render_page(conn, "login.html.eex")
+  end
+
+  post "/login" do
+    raw_key = conn.body_params["api_key"]
+
+    if is_nil(raw_key) or raw_key == "" do
+      render_page(conn, "login.html.eex", flash_error: "API key is required.")
+    else
+      case Lei.ApiKeys.authenticate_key(raw_key) do
+        {:ok, api_key} ->
+          if "admin" in api_key.scopes do
+            conn
+            |> fetch_session()
+            |> put_session("org_slug", api_key.org.slug)
+            |> put_resp_header("location", "/dashboard")
+            |> send_resp(302, "")
+          else
+            render_page(conn, "login.html.eex",
+              flash_error: "This key does not have admin scope. Login requires an admin key."
+            )
+          end
+
+        {:error, _} ->
+          render_page(conn, "login.html.eex", flash_error: "Invalid API key.")
+      end
+    end
+  end
+
+  get "/dashboard" do
+    conn = Lei.Web.SessionAuth.call(conn, [])
+
+    if conn.halted do
+      conn
+    else
+      org = conn.assigns[:current_org]
+      keys = Lei.ApiKeys.list_keys(org)
+      new_key = get_session(conn, "new_key")
+
+      conn =
+        if new_key do
+          delete_session(conn, "new_key")
+        else
+          conn
+        end
+
+      render_page(conn, "dashboard.html.eex", org: org, keys: keys, new_key: new_key)
+    end
+  end
+
+  post "/keys" do
+    conn = Lei.Web.SessionAuth.call(conn, [])
+
+    if conn.halted do
+      conn
+    else
+      org = conn.assigns[:current_org]
+      name = conn.body_params["name"] || "default"
+
+      scopes =
+        case conn.body_params["scopes"] do
+          nil -> []
+          "" -> []
+          s -> s |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.filter(&(&1 != ""))
+        end
+
+      case Lei.ApiKeys.create_api_key(org, name, scopes) do
+        {:ok, raw_key, _api_key} ->
+          keys = Lei.ApiKeys.list_keys(org)
+          render_page(conn, "dashboard.html.eex", org: org, keys: keys, new_key: raw_key)
+
+        {:error, _changeset} ->
+          keys = Lei.ApiKeys.list_keys(org)
+
+          render_page(conn, "dashboard.html.eex",
+            org: org,
+            keys: keys,
+            flash_error: "Failed to create key."
+          )
+      end
+    end
+  end
+
+  post "/keys/:key_id/revoke" do
+    conn = Lei.Web.SessionAuth.call(conn, [])
+
+    if conn.halted do
+      conn
+    else
+      org = conn.assigns[:current_org]
+      Lei.ApiKeys.revoke_key(key_id)
+      keys = Lei.ApiKeys.list_keys(org)
+      render_page(conn, "dashboard.html.eex", org: org, keys: keys, flash_info: "Key revoked.")
+    end
+  end
+
+  get "/logout" do
+    conn
+    |> fetch_session()
+    |> clear_session()
+    |> put_resp_header("location", "/login")
+    |> send_resp(302, "")
+  end
+
+  # --- JSON API routes ---
 
   post "/v1/analyze/batch" do
     case validate_batch_request(conn.body_params) do
@@ -153,6 +309,28 @@ defmodule Lei.Web.Router do
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(404, Poison.encode!(%{error: "not found"}))
+  end
+
+  # --- Private helpers ---
+
+  defp put_secret_key_base(conn, _opts) do
+    secret = Application.get_env(:lowendinsight, :session_secret_key_base)
+    Map.put(conn, :secret_key_base, secret)
+  end
+
+  defp render_page(conn, template, assigns \\ []) do
+    assigns = Keyword.put(assigns, :conn, conn)
+    inner = EEx.eval_file(Path.join(@templates_dir, template), assigns: Enum.into(assigns, %{}))
+    layout_assigns = Keyword.put(assigns, :inner_content, inner)
+
+    body =
+      EEx.eval_file(Path.join(@templates_dir, "layout.html.eex"),
+        assigns: Enum.into(layout_assigns, %{})
+      )
+
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_resp(200, body)
   end
 
   defp validate_batch_request(params) do

--- a/apps/lowendinsight/lib/lei/web/session_auth.ex
+++ b/apps/lowendinsight/lib/lei/web/session_auth.ex
@@ -1,0 +1,37 @@
+defmodule Lei.Web.SessionAuth do
+  @moduledoc """
+  Plug that guards routes behind session authentication.
+  Checks for `org_slug` in session, looks up the org, and assigns it.
+  Redirects to /login if missing or invalid.
+  """
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    conn = Plug.Conn.fetch_session(conn)
+
+    case get_session(conn, "org_slug") do
+      nil ->
+        redirect_to_login(conn)
+
+      slug ->
+        case Lei.ApiKeys.get_org_by_slug(slug) do
+          nil ->
+            conn
+            |> clear_session()
+            |> redirect_to_login()
+
+          org ->
+            assign(conn, :current_org, org)
+        end
+    end
+  end
+
+  defp redirect_to_login(conn) do
+    conn
+    |> put_resp_header("location", "/login")
+    |> send_resp(302, "")
+    |> halt()
+  end
+end

--- a/apps/lowendinsight/lib/risk_logic.ex
+++ b/apps/lowendinsight/lib/risk_logic.ex
@@ -155,4 +155,40 @@ defmodule RiskLogic do
         {:ok, "critical"}
     end
   end
+
+  @doc """
+  agentic_risk/1: returns text enumeration for agentic contribution ratio.
+  Ratio represents the fraction of commits from bots or AI-assisted contributors.
+  """
+  @spec agentic_risk(float) :: {:ok, String.t()}
+  def agentic_risk(ratio) do
+    critical_agentic_level =
+      if Application.fetch_env(:lowendinsight, :critical_agentic_level) == :error,
+        do: 0.9,
+        else: Application.fetch_env!(:lowendinsight, :critical_agentic_level)
+
+    high_agentic_level =
+      if Application.fetch_env(:lowendinsight, :high_agentic_level) == :error,
+        do: 0.7,
+        else: Application.fetch_env!(:lowendinsight, :high_agentic_level)
+
+    medium_agentic_level =
+      if Application.fetch_env(:lowendinsight, :medium_agentic_level) == :error,
+        do: 0.5,
+        else: Application.fetch_env!(:lowendinsight, :medium_agentic_level)
+
+    cond do
+      ratio >= critical_agentic_level ->
+        {:ok, "critical"}
+
+      ratio >= high_agentic_level ->
+        {:ok, "high"}
+
+      ratio >= medium_agentic_level ->
+        {:ok, "medium"}
+
+      ratio < medium_agentic_level ->
+        {:ok, "low"}
+    end
+  end
 end

--- a/apps/lowendinsight/priv/static/css/lei.css
+++ b/apps/lowendinsight/priv/static/css/lei.css
@@ -1,0 +1,9 @@
+/* LEI minimal custom styles — Bulma does the heavy lifting */
+.navbar-brand .navbar-item {
+  font-size: 1.25rem;
+  letter-spacing: 0.05em;
+}
+
+.notification code {
+  word-break: break-all;
+}

--- a/apps/lowendinsight/priv/templates/dashboard.html.eex
+++ b/apps/lowendinsight/priv/templates/dashboard.html.eex
@@ -1,0 +1,66 @@
+<h1 class="title">Dashboard &mdash; <%= @org.name %></h1>
+
+<h2 class="subtitle">API Keys</h2>
+
+<%= if assigns[:new_key] do %>
+  <div class="notification is-warning">
+    <strong>New key created!</strong> Save it now &mdash; it will not be shown again.
+    <br>
+    <code><%= @new_key %></code>
+  </div>
+<% end %>
+
+<table class="table is-fullwidth is-striped">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Prefix</th>
+      <th>Scopes</th>
+      <th>Active</th>
+      <th>Last Used</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for key <- @keys do %>
+      <tr>
+        <td><%= key.name %></td>
+        <td><code><%= key.key_prefix %></code></td>
+        <td><%= Enum.join(key.scopes, ", ") %></td>
+        <td><%= if key.active, do: "Yes", else: "No" %></td>
+        <td><%= key.last_used_at || "Never" %></td>
+        <td>
+          <%= if key.active do %>
+            <form method="post" action="/keys/<%= key.id %>/revoke" style="display:inline">
+              <button class="button is-small is-danger is-outlined" type="submit">Revoke</button>
+            </form>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<h2 class="subtitle mt-5">Create New Key</h2>
+<div class="box" style="max-width: 480px;">
+  <form method="post" action="/keys">
+    <div class="field">
+      <label class="label">Key Name</label>
+      <div class="control">
+        <input class="input" type="text" name="name" placeholder="ci-pipeline" required>
+      </div>
+    </div>
+    <div class="field">
+      <label class="label">Scopes (comma-separated)</label>
+      <div class="control">
+        <input class="input" type="text" name="scopes" placeholder="analyze,admin">
+      </div>
+      <p class="help">Available: analyze, admin</p>
+    </div>
+    <div class="field">
+      <div class="control">
+        <button class="button is-primary" type="submit">Create Key</button>
+      </div>
+    </div>
+  </form>
+</div>

--- a/apps/lowendinsight/priv/templates/layout.html.eex
+++ b/apps/lowendinsight/priv/templates/layout.html.eex
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LEI — LowEndInsight</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
+  <link rel="stylesheet" href="/static/css/lei.css">
+</head>
+<body>
+  <nav class="navbar is-dark" role="navigation" aria-label="main navigation">
+    <div class="navbar-brand">
+      <a class="navbar-item has-text-weight-bold" href="/">LEI</a>
+    </div>
+    <div class="navbar-menu">
+      <div class="navbar-end">
+        <a class="navbar-item" href="/signup">Signup</a>
+        <a class="navbar-item" href="/login">Login</a>
+        <a class="navbar-item" href="/dashboard">Dashboard</a>
+        <a class="navbar-item" href="/logout">Logout</a>
+      </div>
+    </div>
+  </nav>
+
+  <section class="section">
+    <div class="container">
+      <%= if assigns[:flash_error] do %>
+        <div class="notification is-danger"><%= @flash_error %></div>
+      <% end %>
+      <%= if assigns[:flash_info] do %>
+        <div class="notification is-info"><%= @flash_info %></div>
+      <% end %>
+      <%= @inner_content %>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="content has-text-centered">
+      <p>LowEndInsight &mdash; Bus-factor risk analysis</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/apps/lowendinsight/priv/templates/login.html.eex
+++ b/apps/lowendinsight/priv/templates/login.html.eex
@@ -1,0 +1,18 @@
+<h1 class="title">Login</h1>
+<div class="box" style="max-width: 480px;">
+  <form method="post" action="/login">
+    <div class="field">
+      <label class="label">API Key</label>
+      <div class="control">
+        <input class="input" type="password" name="api_key" placeholder="lei_..." required>
+      </div>
+      <p class="help">Enter the admin API key you received at signup.</p>
+    </div>
+    <div class="field">
+      <div class="control">
+        <button class="button is-primary" type="submit">Login</button>
+      </div>
+    </div>
+  </form>
+  <p class="mt-4">Don't have an account? <a href="/signup">Sign up</a></p>
+</div>

--- a/apps/lowendinsight/priv/templates/signup.html.eex
+++ b/apps/lowendinsight/priv/templates/signup.html.eex
@@ -1,0 +1,16 @@
+<h1 class="title">Create an Organization</h1>
+<div class="box" style="max-width: 480px;">
+  <form method="post" action="/signup">
+    <div class="field">
+      <label class="label">Organization Name</label>
+      <div class="control">
+        <input class="input" type="text" name="name" placeholder="My Org" required>
+      </div>
+    </div>
+    <div class="field">
+      <div class="control">
+        <button class="button is-primary" type="submit">Create Organization</button>
+      </div>
+    </div>
+  </form>
+</div>

--- a/apps/lowendinsight/priv/templates/signup_success.html.eex
+++ b/apps/lowendinsight/priv/templates/signup_success.html.eex
@@ -1,0 +1,19 @@
+<h1 class="title">Organization Created</h1>
+<div class="box">
+  <p class="mb-4">Your organization <strong><%= @org_name %></strong> has been created.</p>
+
+  <div class="notification is-warning">
+    <strong>Save your API key now!</strong> It will not be shown again.
+  </div>
+
+  <div class="field">
+    <label class="label">Your Admin API Key</label>
+    <div class="control">
+      <input class="input is-family-monospace" type="text" value="<%= @raw_key %>" readonly>
+    </div>
+  </div>
+
+  <p class="mt-4">
+    <a href="/login" class="button is-link">Login with your API key</a>
+  </p>
+</div>

--- a/apps/lowendinsight/test/lei/agentic_detector_test.exs
+++ b/apps/lowendinsight/test/lei/agentic_detector_test.exs
@@ -1,0 +1,159 @@
+defmodule Lei.AgenticDetectorTest do
+  use ExUnit.Case, async: true
+
+  alias Lei.AgenticDetector
+
+  describe "classify_contributor/2" do
+    test "classifies dependabot as bot by email" do
+      assert AgenticDetector.classify_contributor("dependabot[bot]", "dependabot@github.com") ==
+               :bot
+    end
+
+    test "classifies renovate as bot by email" do
+      assert AgenticDetector.classify_contributor(
+               "Renovate Bot",
+               "renovate@whitesourcesoftware.com"
+             ) ==
+               :bot
+    end
+
+    test "classifies github-actions as bot by name" do
+      assert AgenticDetector.classify_contributor("github-actions[bot]", "noreply@example.com") ==
+               :bot
+    end
+
+    test "classifies bot by github noreply email pattern" do
+      assert AgenticDetector.classify_contributor(
+               "some-bot",
+               "some-bot[bot]@users.noreply.github.com"
+             ) == :bot
+    end
+
+    test "classifies snyk-bot by email" do
+      assert AgenticDetector.classify_contributor("Snyk", "snyk-bot@snyk.io") == :bot
+    end
+
+    test "classifies mergify by name" do
+      assert AgenticDetector.classify_contributor("mergify", "merge@example.com") == :bot
+    end
+
+    test "classifies imgbot by name" do
+      assert AgenticDetector.classify_contributor("imgbot", "img@example.com") == :bot
+    end
+
+    test "classifies semantic-release-bot by name" do
+      assert AgenticDetector.classify_contributor("semantic-release-bot", "release@example.com") ==
+               :bot
+    end
+
+    test "classifies release-please by email" do
+      assert AgenticDetector.classify_contributor(
+               "Release Please",
+               "release-please@google.com"
+             ) == :bot
+    end
+
+    test "classifies normal contributor as human" do
+      assert AgenticDetector.classify_contributor("Jane Doe", "jane@example.com") == :human
+    end
+
+    test "classifies contributor with bot-like but non-matching name as human" do
+      assert AgenticDetector.classify_contributor("robotfan", "robot@example.com") == :human
+    end
+  end
+
+  describe "detect_ai_coauthors/1" do
+    test "detects Claude co-author trailer" do
+      messages = ["feat: add feature\n\nCo-Authored-By: Claude <noreply@anthropic.com>"]
+      result = AgenticDetector.detect_ai_coauthors(messages)
+      assert length(result) > 0
+      assert Enum.any?(result, &String.contains?(&1, "Claude"))
+    end
+
+    test "detects Copilot co-author trailer" do
+      messages = ["fix: bug\n\nCo-Authored-By: GitHub Copilot <copilot@github.com>"]
+      result = AgenticDetector.detect_ai_coauthors(messages)
+      assert length(result) > 0
+    end
+
+    test "detects Cursor co-author trailer" do
+      messages = ["refactor: cleanup\n\nCo-Authored-By: Cursor AI <cursor@cursor.com>"]
+      result = AgenticDetector.detect_ai_coauthors(messages)
+      assert length(result) > 0
+    end
+
+    test "returns empty list for normal commits" do
+      messages = ["feat: normal feature", "fix: normal bug fix"]
+      assert AgenticDetector.detect_ai_coauthors(messages) == []
+    end
+
+    test "deduplicates across messages" do
+      messages = [
+        "feat: one\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+        "feat: two\n\nCo-Authored-By: Claude <noreply@anthropic.com>"
+      ]
+
+      result = AgenticDetector.detect_ai_coauthors(messages)
+      assert length(result) == 1
+    end
+
+    test "returns empty list for empty input" do
+      assert AgenticDetector.detect_ai_coauthors([]) == []
+    end
+  end
+
+  describe "analyze/2" do
+    test "analyzes mixed contributors" do
+      contributors_with_messages = [
+        {%{name: "Jane Doe", email: "jane@example.com", count: 50}, ["feat: add stuff"]},
+        {%{name: "dependabot[bot]", email: "dependabot@github.com", count: 20},
+         ["chore: bump deps"]},
+        {%{name: "Bob Smith", email: "bob@example.com", count: 30},
+         ["fix: thing\n\nCo-Authored-By: Claude <noreply@anthropic.com>"]}
+      ]
+
+      result = AgenticDetector.analyze(contributors_with_messages, 3)
+
+      assert result.human_contributor_count == 1
+      assert length(result.bot_contributors) == 1
+      assert "dependabot[bot]" in result.bot_contributors
+      assert length(result.agent_contributors) == 1
+      assert "Bob Smith" in result.agent_contributors
+      assert result.agentic_contribution_ratio == 0.5
+      assert result.human_functional_contributors == 2
+    end
+
+    test "analyzes all-human contributors" do
+      contributors_with_messages = [
+        {%{name: "Jane", email: "jane@example.com", count: 10}, ["feat: one"]},
+        {%{name: "Bob", email: "bob@example.com", count: 10}, ["feat: two"]}
+      ]
+
+      result = AgenticDetector.analyze(contributors_with_messages, 2)
+
+      assert result.human_contributor_count == 2
+      assert result.bot_contributors == []
+      assert result.agent_contributors == []
+      assert result.agentic_contribution_ratio == 0.0
+    end
+
+    test "handles empty contributor list" do
+      result = AgenticDetector.analyze([], 0)
+
+      assert result.human_contributor_count == 0
+      assert result.bot_contributors == []
+      assert result.agent_contributors == []
+      assert result.agentic_contribution_ratio == 0.0
+      assert result.classified_contributors == []
+    end
+
+    test "bot commits count toward agentic ratio" do
+      contributors_with_messages = [
+        {%{name: "dependabot[bot]", email: "dependabot@github.com", count: 100}, ["chore: bump"]}
+      ]
+
+      result = AgenticDetector.analyze(contributors_with_messages, 0)
+      assert result.agentic_contribution_ratio == 1.0
+    end
+  end
+end

--- a/apps/lowendinsight/test/lei/auth_test.exs
+++ b/apps/lowendinsight/test/lei/auth_test.exs
@@ -11,7 +11,10 @@ defmodule Lei.AuthTest do
     Lei.RateLimiter.clear()
 
     {:ok, org} = Lei.ApiKeys.find_or_create_org("Auth Test Org")
-    {:ok, raw_key, _api_key} = Lei.ApiKeys.create_api_key(org, "auth-test-key", ["analyze", "admin"])
+
+    {:ok, raw_key, _api_key} =
+      Lei.ApiKeys.create_api_key(org, "auth-test-key", ["analyze", "admin"])
+
     %{raw_key: raw_key}
   end
 

--- a/apps/lowendinsight/test/lei/registration_test.exs
+++ b/apps/lowendinsight/test/lei/registration_test.exs
@@ -62,7 +62,11 @@ defmodule Lei.RegistrationTest do
   describe "POST /v1/orgs/:slug/keys" do
     test "creates an API key for org", %{admin_key: key, org: org} do
       conn =
-        conn(:post, "/v1/orgs/#{org.slug}/keys", Poison.encode!(%{name: "ci-key", scopes: ["analyze"]}))
+        conn(
+          :post,
+          "/v1/orgs/#{org.slug}/keys",
+          Poison.encode!(%{name: "ci-key", scopes: ["analyze"]})
+        )
         |> put_req_header("content-type", "application/json")
         |> put_req_header("authorization", "Bearer #{key}")
         |> Lei.Web.Router.call(@opts)

--- a/apps/lowendinsight/test/lei/web/session_auth_test.exs
+++ b/apps/lowendinsight/test/lei/web/session_auth_test.exs
@@ -1,0 +1,60 @@
+defmodule Lei.Web.SessionAuthTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Lei.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Lei.Repo, {:shared, self()})
+    :ok
+  end
+
+  defp build_conn_with_session(session_data) do
+    secret = Application.get_env(:lowendinsight, :session_secret_key_base)
+
+    opts =
+      Plug.Session.init(
+        store: :cookie,
+        key: "_lei_session",
+        signing_salt: "lei_auth",
+        secret_key_base: secret
+      )
+
+    Plug.Test.conn(:get, "/dashboard")
+    |> Map.put(:secret_key_base, secret)
+    |> Plug.Session.call(opts)
+    |> Plug.Conn.fetch_session()
+    |> then(fn conn ->
+      Enum.reduce(session_data, conn, fn {k, v}, acc ->
+        Plug.Conn.put_session(acc, k, v)
+      end)
+    end)
+  end
+
+  test "redirects to /login when no session" do
+    conn = build_conn_with_session(%{})
+    conn = Lei.Web.SessionAuth.call(conn, [])
+
+    assert conn.status == 302
+    assert Plug.Conn.get_resp_header(conn, "location") == ["/login"]
+    assert conn.halted
+  end
+
+  test "redirects to /login when org_slug is invalid" do
+    conn = build_conn_with_session(%{"org_slug" => "nonexistent-org"})
+    conn = Lei.Web.SessionAuth.call(conn, [])
+
+    assert conn.status == 302
+    assert Plug.Conn.get_resp_header(conn, "location") == ["/login"]
+    assert conn.halted
+  end
+
+  test "assigns current_org when session is valid" do
+    {:ok, org} = Lei.ApiKeys.find_or_create_org("Session Test Org")
+
+    conn = build_conn_with_session(%{"org_slug" => org.slug})
+    conn = Lei.Web.SessionAuth.call(conn, [])
+
+    refute conn.halted
+    assert conn.assigns[:current_org].id == org.id
+    assert conn.assigns[:current_org].slug == org.slug
+  end
+end

--- a/apps/lowendinsight/test/lei/web/ui_test.exs
+++ b/apps/lowendinsight/test/lei/web/ui_test.exs
@@ -1,0 +1,99 @@
+defmodule Lei.Web.UiTest do
+  use ExUnit.Case, async: false
+
+  @opts Lei.Web.Router.init([])
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Lei.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Lei.Repo, {:shared, self()})
+    :ok
+  end
+
+  defp call(conn) do
+    Lei.Web.Router.call(conn, @opts)
+  end
+
+  test "GET /signup renders signup form" do
+    conn = Plug.Test.conn(:get, "/signup") |> call()
+    assert conn.status == 200
+    assert conn.resp_body =~ "Create an Organization"
+    assert conn.resp_body =~ "<form"
+  end
+
+  test "POST /signup creates org and shows API key" do
+    conn =
+      Plug.Test.conn(:post, "/signup", "name=TestUIOrg")
+      |> Plug.Conn.put_req_header("content-type", "application/x-www-form-urlencoded")
+      |> call()
+
+    assert conn.status == 200
+    assert conn.resp_body =~ "lei_"
+    assert conn.resp_body =~ "Save your API key"
+    assert conn.resp_body =~ "TestUIOrg"
+  end
+
+  test "POST /signup with empty name shows error" do
+    conn =
+      Plug.Test.conn(:post, "/signup", "name=")
+      |> Plug.Conn.put_req_header("content-type", "application/x-www-form-urlencoded")
+      |> call()
+
+    assert conn.status == 200
+    assert conn.resp_body =~ "Organization name is required"
+  end
+
+  test "GET /login renders login form" do
+    conn = Plug.Test.conn(:get, "/login") |> call()
+    assert conn.status == 200
+    assert conn.resp_body =~ "API Key"
+    assert conn.resp_body =~ "<form"
+  end
+
+  test "POST /login with valid admin key redirects to /dashboard" do
+    {:ok, org} = Lei.ApiKeys.find_or_create_org("Login Test Org")
+    {:ok, raw_key, _api_key} = Lei.ApiKeys.create_api_key(org, "admin", ["admin", "analyze"])
+
+    conn =
+      Plug.Test.conn(:post, "/login", "api_key=#{raw_key}")
+      |> Plug.Conn.put_req_header("content-type", "application/x-www-form-urlencoded")
+      |> call()
+
+    assert conn.status == 302
+    assert Plug.Conn.get_resp_header(conn, "location") == ["/dashboard"]
+  end
+
+  test "POST /login with invalid key shows error" do
+    conn =
+      Plug.Test.conn(:post, "/login", "api_key=lei_invalid_key_here")
+      |> Plug.Conn.put_req_header("content-type", "application/x-www-form-urlencoded")
+      |> call()
+
+    assert conn.status == 200
+    assert conn.resp_body =~ "Invalid API key"
+  end
+
+  test "POST /login with non-admin key shows scope error" do
+    {:ok, org} = Lei.ApiKeys.find_or_create_org("NonAdmin Test Org")
+    {:ok, raw_key, _api_key} = Lei.ApiKeys.create_api_key(org, "analyze-only", ["analyze"])
+
+    conn =
+      Plug.Test.conn(:post, "/login", "api_key=#{raw_key}")
+      |> Plug.Conn.put_req_header("content-type", "application/x-www-form-urlencoded")
+      |> call()
+
+    assert conn.status == 200
+    assert conn.resp_body =~ "admin scope"
+  end
+
+  test "GET /dashboard without session redirects to /login" do
+    conn = Plug.Test.conn(:get, "/dashboard") |> call()
+    assert conn.status == 302
+    assert Plug.Conn.get_resp_header(conn, "location") == ["/login"]
+  end
+
+  test "GET /logout redirects to /login" do
+    conn = Plug.Test.conn(:get, "/logout") |> call()
+    assert conn.status == 302
+    assert Plug.Conn.get_resp_header(conn, "location") == ["/login"]
+  end
+end

--- a/apps/lowendinsight/test/risk_logic_test.exs
+++ b/apps/lowendinsight/test/risk_logic_test.exs
@@ -178,6 +178,29 @@ defmodule RiskLogicTest do
     assert RiskLogic.functional_contributors_risk(100) == {:ok, "low"}
   end
 
+  describe "agentic_risk" do
+    test "low when ratio below 0.5" do
+      assert RiskLogic.agentic_risk(0.0) == {:ok, "low"}
+      assert RiskLogic.agentic_risk(0.3) == {:ok, "low"}
+      assert RiskLogic.agentic_risk(0.49) == {:ok, "low"}
+    end
+
+    test "medium when ratio at or above 0.5" do
+      assert RiskLogic.agentic_risk(0.5) == {:ok, "medium"}
+      assert RiskLogic.agentic_risk(0.6) == {:ok, "medium"}
+    end
+
+    test "high when ratio at or above 0.7" do
+      assert RiskLogic.agentic_risk(0.7) == {:ok, "high"}
+      assert RiskLogic.agentic_risk(0.8) == {:ok, "high"}
+    end
+
+    test "critical when ratio at or above 0.9" do
+      assert RiskLogic.agentic_risk(0.9) == {:ok, "critical"}
+      assert RiskLogic.agentic_risk(1.0) == {:ok, "critical"}
+    end
+  end
+
   describe "config fallback branches" do
     test "contributor_risk uses defaults when config is missing" do
       # Save and remove the config
@@ -290,6 +313,31 @@ defmodule RiskLogicTest do
             :critical_functional_contributors_level,
             original_critical
           )
+    end
+
+    test "agentic_risk uses defaults when config is missing" do
+      original_critical = Application.get_env(:lowendinsight, :critical_agentic_level)
+      original_high = Application.get_env(:lowendinsight, :high_agentic_level)
+      original_medium = Application.get_env(:lowendinsight, :medium_agentic_level)
+
+      Application.delete_env(:lowendinsight, :critical_agentic_level)
+      Application.delete_env(:lowendinsight, :high_agentic_level)
+      Application.delete_env(:lowendinsight, :medium_agentic_level)
+
+      # Defaults: medium=0.5, high=0.7, critical=0.9
+      assert RiskLogic.agentic_risk(0.3) == {:ok, "low"}
+      assert RiskLogic.agentic_risk(0.5) == {:ok, "medium"}
+      assert RiskLogic.agentic_risk(0.7) == {:ok, "high"}
+      assert RiskLogic.agentic_risk(0.9) == {:ok, "critical"}
+
+      if original_critical,
+        do: Application.put_env(:lowendinsight, :critical_agentic_level, original_critical)
+
+      if original_high,
+        do: Application.put_env(:lowendinsight, :high_agentic_level, original_high)
+
+      if original_medium,
+        do: Application.put_env(:lowendinsight, :medium_agentic_level, original_medium)
     end
   end
 end

--- a/apps/lowendinsight_get/lib/lowendinsight_get/application.ex
+++ b/apps/lowendinsight_get/lib/lowendinsight_get/application.ex
@@ -38,10 +38,20 @@ defmodule LowendinsightGet.Application do
       end
 
     redix_opts =
-      [name: :redix, sync_connect: false, exit_on_disconnection: false,
-       host: host, port: port, password: password, ssl: ssl?, database: database]
+      [
+        name: :redix,
+        sync_connect: false,
+        exit_on_disconnection: false,
+        host: host,
+        port: port,
+        password: password,
+        ssl: ssl?,
+        database: database
+      ]
 
-    Logger.info("Redix opts (sans password): host=#{host} port=#{port} db=#{database} ssl=#{ssl?}")
+    Logger.info(
+      "Redix opts (sans password): host=#{host} port=#{port} db=#{database} ssl=#{ssl?}"
+    )
 
     kids = [
       {Redix, redix_opts},

--- a/config/config.exs
+++ b/config/config.exs
@@ -87,7 +87,16 @@ config :lowendinsight,
       System.get_env("LEI_MEDIUM_FUNCTIONAL_CONTRIBUTORS_LEVEL") || "5"
     ),
   jobs_per_core_max: String.to_integer(System.get_env("LEI_JOBS_PER_CORE_MAX") || "1"),
-  base_temp_dir: System.get_env("LEI_BASE_TEMP_DIR") || "/tmp"
+  base_temp_dir: System.get_env("LEI_BASE_TEMP_DIR") || "/tmp",
+  critical_agentic_level:
+    String.to_float(System.get_env("LEI_CRITICAL_AGENTIC_LEVEL") || "0.9"),
+  high_agentic_level:
+    String.to_float(System.get_env("LEI_HIGH_AGENTIC_LEVEL") || "0.7"),
+  medium_agentic_level:
+    String.to_float(System.get_env("LEI_MEDIUM_AGENTIC_LEVEL") || "0.5"),
+  session_secret_key_base:
+    System.get_env("LEI_SESSION_SECRET") ||
+      "lei_dev_session_secret_that_is_at_least_64_bytes_long_for_cookie_store_to_work_properly"
 
 # JsonXema Schema Loader
 config :xema, loader: SchemaLoader


### PR DESCRIPTION
## Summary
- **Auth UI**: Adds web signup, login (API-key-as-credential), and key management dashboard on Lei.Web.Router with session-based cookie auth, EEX templates (Bulma CSS), and SessionAuth plug
- **Agentic Detection**: New `Lei.AgenticDetector` module classifies contributors as human/bot/agent via email/name patterns and `Co-Authored-By` trailer analysis (Claude, Copilot, Cursor, Windsurf, Devin)
- **Risk Metric**: Adds `agentic_risk` to `RiskLogic` and integrates `agentic_contribution_ratio`, `human_contributor_count`, `human_functional_contributors`, and `agentic_contributors` into the analysis report

## Test plan
- [x] `mix test` — 90 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [ ] Manual: POST /signup → creates org + shows raw key
- [ ] Manual: POST /login with admin key → redirects to /dashboard
- [ ] Manual: Dashboard shows keys, create/revoke work
- [ ] Manual: Analyze a repo with bot contributors → agentic fields in report

🤖 Generated with [Claude Code](https://claude.com/claude-code)