### PR TITLE
fix(ci): upgrade hex_publish workflow to Elixir 1.16.3

### DIFF
--- a/.github/workflows/hex_publish.yml
+++ b/.github/workflows/hex_publish.yml
@@ -8,25 +8,23 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
-    container:
-      image: elixir:1.14-alpine
-
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+    - name: Setup Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        elixir-version: 1.16.3
+        otp-version: 26.2
     - name: Install Dependencies
       run: |
-        apk add git
         mix local.rebar --force
         mix local.hex --force
         mix deps.get
     - name: Publish to Hex
-      env: # Or as an environment variable
+      env:
         HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
       if: github.event.pull_request.merged == true
       run: |
-        git config --global --add safe.directory /__w/lowendinsight/lowendinsight
         cd apps/lowendinsight && mix hex.publish --yes
-


### PR DESCRIPTION
## Summary
- Upgrade hex_publish workflow from `elixir:1.14-alpine` container to `erlef/setup-beam` with Elixir 1.16.3 / OTP 26.2
- Fixes compilation failure: `postgrex ~> 0.18` requires Elixir `~> 1.15` but hex_publish was running 1.14.5
- Aligns with `umbrella_ci` workflow which already uses 1.16.3
- Also upgrades `actions/checkout` from v1 to v4

## Test plan
- [ ] Merge this PR → hex_publish workflow should trigger and succeed (or skip if `HEX_API_KEY` not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)