### PR TITLE
fix(ci): trigger hex_publish on version tags only

### DIFF
--- a/.github/workflows/hex_publish.yml
+++ b/.github/workflows/hex_publish.yml
@@ -1,13 +1,12 @@
-name: elixir_ci_hex_publish
+name: hex_publish
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
+  push:
+    tags:
+      - 'v*'
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,6 +24,5 @@ jobs:
     - name: Publish to Hex
       env:
         HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-      if: github.event.pull_request.merged == true
       run: |
         cd apps/lowendinsight && mix hex.publish --yes


### PR DESCRIPTION
## Summary
- Change hex_publish trigger from `pull_request: types: [closed]` to `push: tags: [v*]`
- The workflow was failing because it tried to re-publish version 0.9.1 on every merged PR, but hex.pm only allows modification within 1 hour of initial publication
- Now aligns with `release.yml` — publish only happens when a version tag is pushed

## Test plan
- [x] After merge, no hex_publish run fires (no tag push)
- [ ] On next `git tag v0.9.2 && git push --tags`, hex_publish triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)