### PR TITLE
Wire auth UI routes into deployed endpoint

### DIFF
--- a/apps/lowendinsight/priv/templates/layout.html.eex
+++ b/apps/lowendinsight/priv/templates/layout.html.eex
@@ -10,7 +10,9 @@
 <body>
   <nav class="navbar is-dark" role="navigation" aria-label="main navigation">
     <div class="navbar-brand">
-      <a class="navbar-item has-text-weight-bold" href="/">LEI</a>
+      <a class="navbar-item" href="/">
+        <img src="/images/lei_bus_128.png" alt="LEI" style="max-height:40px;">
+      </a>
     </div>
     <div class="navbar-menu">
       <div class="navbar-end">

--- a/apps/lowendinsight_get/lib/lowendinsight_get/endpoint.ex
+++ b/apps/lowendinsight_get/lib/lowendinsight_get/endpoint.ex
@@ -13,6 +13,8 @@ defmodule LowendinsightGet.Endpoint do
 
   require Logger
   alias Plug.{Adapters.Cowboy}
+  @auth_paths ~w(/signup /login /dashboard /keys /logout /static)
+
   plug(LowendinsightGet.Auth)
   plug(Plug.Logger, log: :debug)
   plug(Plug.Static, from: "priv/static/images", at: "/images")
@@ -25,6 +27,7 @@ defmodule LowendinsightGet.Endpoint do
     json_decoder: Poison
   )
 
+  plug(:maybe_route_auth)
   plug(:match)
   plug(:dispatch)
 
@@ -417,4 +420,12 @@ defmodule LowendinsightGet.Endpoint do
   end
 
   defp config, do: Application.fetch_env(:lowendinsight_get, __MODULE__)
+
+  defp maybe_route_auth(%Plug.Conn{request_path: path} = conn, _opts) do
+    if Enum.any?(@auth_paths, &String.starts_with?(path, &1)) do
+      Lei.Web.Router.call(conn, Lei.Web.Router.init([]))
+    else
+      conn
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Auth UI routes (signup, login, dashboard, key management, logout) were only accessible via `Lei.Web.Router` on port 4000, but the deployed Fly.io release runs `LowendinsightGet.Endpoint` on port 8080
- Added `maybe_route_auth` plug to `LowendinsightGet.Endpoint` that delegates auth paths to `Lei.Web.Router`
- Fixed navbar logo in auth layout to use the LEI bus image instead of plain text

## Test plan
- [x] All 90 existing tests pass
- [ ] Verify `/signup`, `/login`, `/dashboard` render correctly on deployed app
- [ ] Verify LEI logo appears in auth page navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)