### PR TITLE
feat(tqm): TQM circuit breaker for batch success rate (lowendinsight-52)

### DIFF
--- a/lib/lei/application.ex
+++ b/lib/lei/application.ex
@@ -10,7 +10,7 @@ defmodule Lei.Application do
   def start(_type, _args) do
     port = Application.get_env(:lowendinsight, :http_port, 4000)
 
-    base = [Lei.Repo, Lei.BatchCache, Lei.RateLimiter]
+    base = [Lei.Repo, Lei.BatchCache, Lei.RateLimiter, Lei.TQM]
 
     children =
       if Application.get_env(:lowendinsight, :start_http, false) do

--- a/lib/lei/tqm.ex
+++ b/lib/lei/tqm.ex
@@ -1,0 +1,158 @@
+defmodule Lei.TQM do
+  @moduledoc """
+  Total Quality Management for batch analysis runs.
+
+  Tracks batch success rates in a sliding window and implements a
+  circuit breaker that halts further batch runs when the rate drops
+  below the configured threshold.
+
+  The circuit opens when:
+  - At least `min_sample` outcomes are in the current window
+  - Success rate < `threshold` (default 50%)
+
+  The circuit auto-resets to closed after `reset_after_ms` (default 5 minutes),
+  allowing runs to resume once the window has aged out.
+
+  Configuration options (passed to `start_link/1`):
+  - `:window_size`    - sliding window size (default 10)
+  - `:threshold`      - minimum acceptable success rate, 0.0–1.0 (default 0.5)
+  - `:min_sample`     - minimum window count before circuit can open (default 1)
+  - `:reset_after_ms` - ms after opening before auto-reset (default 300_000)
+  - `:name`           - registered name (default `Lei.TQM`)
+  """
+
+  use GenServer
+
+  @default_window_size 10
+  @default_threshold 0.5
+  @default_min_sample 1
+  @default_reset_after_ms 5 * 60 * 1_000
+
+  defstruct outcomes: [],
+            window_size: @default_window_size,
+            threshold: @default_threshold,
+            min_sample: @default_min_sample,
+            reset_after_ms: @default_reset_after_ms,
+            circuit_opened_at: nil,
+            total_runs: 0,
+            total_successes: 0
+
+  # --- Client API ---
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "Record a successful batch run."
+  def record_success(server \\ __MODULE__) do
+    GenServer.cast(server, {:record, :ok})
+  end
+
+  @doc "Record a failed batch run."
+  def record_failure(server \\ __MODULE__) do
+    GenServer.cast(server, {:record, :error})
+  end
+
+  @doc "Returns `:open` when batch runs are halted, `:closed` otherwise."
+  def circuit_state(server \\ __MODULE__) do
+    GenServer.call(server, :circuit_state)
+  end
+
+  @doc "Returns a map describing current TQM state for observability."
+  def status(server \\ __MODULE__) do
+    GenServer.call(server, :status)
+  end
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(opts) do
+    state = %__MODULE__{
+      window_size: Keyword.get(opts, :window_size, @default_window_size),
+      threshold: Keyword.get(opts, :threshold, @default_threshold),
+      min_sample: Keyword.get(opts, :min_sample, @default_min_sample),
+      reset_after_ms: Keyword.get(opts, :reset_after_ms, @default_reset_after_ms)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_cast({:record, outcome}, state) do
+    outcomes = [outcome | state.outcomes] |> Enum.take(state.window_size)
+    total_runs = state.total_runs + 1
+    total_successes = state.total_successes + if outcome == :ok, do: 1, else: 0
+
+    new_state = %{
+      state
+      | outcomes: outcomes,
+        total_runs: total_runs,
+        total_successes: total_successes
+    }
+
+    {:noreply, maybe_open_circuit(new_state)}
+  end
+
+  @impl true
+  def handle_call(:circuit_state, _from, state) do
+    state = maybe_reset_circuit(state)
+    result = if state.circuit_opened_at, do: :open, else: :closed
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call(:status, _from, state) do
+    state = maybe_reset_circuit(state)
+    success_rate = compute_success_rate(state.outcomes)
+
+    result = %{
+      circuit: if(state.circuit_opened_at, do: "open", else: "closed"),
+      circuit_opened_at: state.circuit_opened_at,
+      window_size: state.window_size,
+      window_count: length(state.outcomes),
+      success_rate: Float.round(success_rate * 100, 1),
+      threshold_pct: Float.round(state.threshold * 100, 1),
+      total_runs: state.total_runs,
+      total_successes: state.total_successes
+    }
+
+    {:reply, result, state}
+  end
+
+  # --- Private ---
+
+  defp maybe_open_circuit(%{circuit_opened_at: opened} = state) when not is_nil(opened) do
+    # Already open; don't re-open
+    state
+  end
+
+  defp maybe_open_circuit(state) do
+    rate = compute_success_rate(state.outcomes)
+
+    if length(state.outcomes) >= state.min_sample and rate < state.threshold do
+      %{state | circuit_opened_at: System.monotonic_time(:millisecond)}
+    else
+      state
+    end
+  end
+
+  defp maybe_reset_circuit(%{circuit_opened_at: nil} = state), do: state
+
+  defp maybe_reset_circuit(state) do
+    now = System.monotonic_time(:millisecond)
+
+    if now - state.circuit_opened_at >= state.reset_after_ms do
+      %{state | circuit_opened_at: nil, outcomes: []}
+    else
+      state
+    end
+  end
+
+  defp compute_success_rate([]), do: 1.0
+
+  defp compute_success_rate(outcomes) do
+    successes = Enum.count(outcomes, &(&1 == :ok))
+    successes / length(outcomes)
+  end
+end

--- a/test/lei/tqm_test.exs
+++ b/test/lei/tqm_test.exs
@@ -1,0 +1,132 @@
+defmodule Lei.TQMTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    name = :"tqm_test_#{:erlang.unique_integer([:positive])}"
+    {:ok, pid} = Lei.TQM.start_link(name: name, window_size: 5, threshold: 0.5, min_sample: 1)
+    %{tqm: pid}
+  end
+
+  test "circuit starts closed", %{tqm: tqm} do
+    assert Lei.TQM.circuit_state(tqm) == :closed
+  end
+
+  test "circuit stays closed with only successes", %{tqm: tqm} do
+    Lei.TQM.record_success(tqm)
+    Lei.TQM.record_success(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :closed
+  end
+
+  test "circuit opens when success rate drops below threshold", %{tqm: tqm} do
+    # 0/2 = 0.0% < 50% threshold
+    Lei.TQM.record_failure(tqm)
+    Lei.TQM.record_failure(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :open
+  end
+
+  test "circuit stays open after more failures", %{tqm: tqm} do
+    Lei.TQM.record_failure(tqm)
+    Lei.TQM.record_failure(tqm)
+    Lei.TQM.record_failure(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :open
+  end
+
+  test "mixed results: circuit opens when rate drops below threshold", %{tqm: tqm} do
+    # 1 success then 3 failures => 1/4 = 25% < 50%
+    Lei.TQM.record_success(tqm)
+    Lei.TQM.record_failure(tqm)
+    Lei.TQM.record_failure(tqm)
+    Lei.TQM.record_failure(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :open
+  end
+
+  test "circuit stays closed when rate is at or above threshold", %{tqm: tqm} do
+    # 1/2 = 50% == threshold, should stay closed
+    Lei.TQM.record_success(tqm)
+    Lei.TQM.record_failure(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :closed
+  end
+
+  test "sliding window evicts oldest outcomes", %{tqm: tqm} do
+    # Fill with failures to open
+    Lei.TQM.record_failure(tqm)
+    Lei.TQM.record_failure(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :open
+
+    # Start a fresh server to test window eviction in isolation
+    name2 = :"tqm_window_#{:erlang.unique_integer([:positive])}"
+    {:ok, tqm2} = Lei.TQM.start_link(name: name2, window_size: 3, threshold: 0.5, min_sample: 1)
+    # 3 successes fills the window
+    Lei.TQM.record_success(tqm2)
+    Lei.TQM.record_success(tqm2)
+    Lei.TQM.record_success(tqm2)
+    # Then 2 failures — oldest success gets pushed out, window: [fail, fail, success] => 1/3 < 50%
+    Lei.TQM.record_failure(tqm2)
+    Lei.TQM.record_failure(tqm2)
+    assert Lei.TQM.circuit_state(tqm2) == :open
+  end
+
+  test "status returns expected fields", %{tqm: tqm} do
+    Lei.TQM.record_success(tqm)
+    Lei.TQM.record_failure(tqm)
+
+    status = Lei.TQM.status(tqm)
+
+    assert status.circuit in ["open", "closed"]
+    assert is_float(status.success_rate)
+    assert is_float(status.threshold_pct)
+    assert is_integer(status.window_count)
+    assert is_integer(status.total_runs)
+    assert is_integer(status.total_successes)
+    assert status.total_runs == 2
+    assert status.total_successes == 1
+  end
+
+  test "status reports correct success rate", %{tqm: tqm} do
+    Lei.TQM.record_success(tqm)
+    Lei.TQM.record_success(tqm)
+    Lei.TQM.record_failure(tqm)
+    Lei.TQM.record_failure(tqm)
+
+    status = Lei.TQM.status(tqm)
+    assert status.success_rate == 50.0
+  end
+
+  test "circuit auto-resets after reset_after_ms", %{} do
+    name = :"tqm_reset_#{:erlang.unique_integer([:positive])}"
+    {:ok, tqm} = Lei.TQM.start_link(name: name, min_sample: 1, threshold: 0.5, reset_after_ms: 50)
+
+    Lei.TQM.record_failure(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :open
+
+    Process.sleep(60)
+    assert Lei.TQM.circuit_state(tqm) == :closed
+  end
+
+  test "min_sample prevents circuit from opening prematurely" do
+    name = :"tqm_minsample_#{:erlang.unique_integer([:positive])}"
+    {:ok, tqm} = Lei.TQM.start_link(name: name, min_sample: 3, threshold: 0.5)
+
+    # Only 2 failures — below min_sample of 3
+    Lei.TQM.record_failure(tqm)
+    Lei.TQM.record_failure(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :closed
+
+    # Third failure hits min_sample — circuit opens
+    Lei.TQM.record_failure(tqm)
+    assert Lei.TQM.circuit_state(tqm) == :open
+  end
+
+  test "total_runs and total_successes accumulate across window rollovers" do
+    name = :"tqm_totals_#{:erlang.unique_integer([:positive])}"
+    {:ok, tqm} = Lei.TQM.start_link(name: name, window_size: 2, threshold: 0.1, min_sample: 1)
+
+    for _ <- 1..5, do: Lei.TQM.record_success(tqm)
+
+    status = Lei.TQM.status(tqm)
+    assert status.total_runs == 5
+    assert status.total_successes == 5
+    # Window only holds last 2
+    assert status.window_count == 2
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Lei.TQM` GenServer implementing a sliding-window circuit breaker that halts batch runs when success rate drops below a configurable threshold (default 50%)
- Registers `Lei.TQM` in the OTP supervision tree via `Lei.Application`
- Covers the `low_success_rate` critical condition: batch success rate 0.0% (0/2) triggers the circuit open state with a remediation path via auto-reset after `reset_after_ms`

## Key behaviour

| Config | Default | Description |
|---|---|---|
| `window_size` | 10 | Sliding window depth |
| `threshold` | 0.5 | Min acceptable success rate |
| `min_sample` | 1 | Minimum samples before circuit can open |
| `reset_after_ms` | 300 000 | Cooldown before auto-reset to closed |

## Test plan

- [x] Circuit starts closed
- [x] Stays closed with only successes
- [x] Opens at 0% success rate (the reported failure scenario)
- [x] Stays closed at exactly threshold (50%)
- [x] `min_sample` prevents premature tripping
- [x] Sliding window evicts oldest outcomes correctly
- [x] Auto-resets to closed after `reset_after_ms`
- [x] `status/1` returns all observability fields with correct values
- [x] Lifetime totals accumulate correctly across window rollovers
- All 12 tests pass (`mix test test/lei/tqm_test.exs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)