### PR TITLE
fix(gh_trending): replace dead fly.dev API with direct GitHub trending scrape

### DIFF
--- a/apps/lowendinsight_get/lib/lowendinsight_get/github_trending.ex
+++ b/apps/lowendinsight_get/lib/lowendinsight_get/github_trending.ex
@@ -128,16 +128,17 @@ defmodule LowendinsightGet.GithubTrending do
   end
 
   defp fetch_trending_list(language) do
-    url =
-      "https://github-trending-api.fly.dev/repositories?since=daily&language=" <>
-        URI.encode_www_form(language)
+    url = "https://github.com/trending/#{URI.encode_www_form(language)}?since=daily"
 
     Logger.info("fetching trend list for: #{url}")
 
-    case HTTPoison.get(url)
+    headers = [{"User-Agent", "Mozilla/5.0 (compatible; lowendinsight-bot/1.0)"}]
+
+    case HTTPoison.get(url, headers)
          |> HTTPoison.Retry.autoretry(max_attempts: 5, wait: 15000, retry_unknown_errors: true) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, Poison.Parser.parse!(body, %{})}
+        repos = parse_trending_html(body)
+        {:ok, repos}
 
       {:ok, %HTTPoison.Response{status_code: 404}} ->
         {:error, "Not found :("}
@@ -146,5 +147,13 @@ defmodule LowendinsightGet.GithubTrending do
         Logger.error(reason)
         {:error, reason}
     end
+  end
+
+  def parse_trending_html(html) do
+    # GitHub trending page: repos are listed in <h2 class="h3 lh-condensed"><a href="/owner/repo">
+    regex = ~r/<h2[^>]*class="h3 lh-condensed"[^>]*>\s*<a\s+href="\/([a-zA-Z0-9][a-zA-Z0-9_.-]*\/[a-zA-Z0-9][a-zA-Z0-9_.-]*)"/
+
+    Regex.scan(regex, html, capture: :all_but_first)
+    |> Enum.map(fn [slug] -> %{"url" => "https://github.com/#{String.trim(slug)}"} end)
   end
 end

--- a/apps/lowendinsight_get/test/lowendinsight_get/github_trending_test.exs
+++ b/apps/lowendinsight_get/test/lowendinsight_get/github_trending_test.exs
@@ -39,4 +39,21 @@ defmodule LowendinsightGet.GithubTrendingTest do
     wait_time = Application.fetch_env!(:lowendinsight_get, :wait_time)
     assert wait_time == LowendinsightGet.GithubTrending.get_wait_time()
   end
+
+  test "parses github trending html into repo url list" do
+    html = """
+    <h2 class="h3 lh-condensed">
+      <a href="/elixir-lang/elixir">elixir-lang / elixir</a>
+    </h2>
+    <h2 class="h3 lh-condensed">
+      <a href="/phoenixframework/phoenix">phoenixframework / phoenix</a>
+    </h2>
+    """
+
+    repos = LowendinsightGet.GithubTrending.parse_trending_html(html)
+
+    assert length(repos) == 2
+    assert Enum.member?(repos, %{"url" => "https://github.com/elixir-lang/elixir"})
+    assert Enum.member?(repos, %{"url" => "https://github.com/phoenixframework/phoenix"})
+  end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -121,7 +121,7 @@ config :redix,
 config :lowendinsight_get, LowendinsightGet.Scheduler,
   jobs: [
     {"*/5 * * * *", {LowendinsightGet.CacheCleaner, :clean, []}},
-    {"0 0 * * *", {LowendinsightGet.GithubTrending, :analyze, []}}
+    {"0 0 * * *", {LowendinsightGet.GithubTrending, :process_languages, []}}
   ]
 
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
## Summary

- Replaces the dead `github-trending-api.fly.dev` (NXDOMAIN) with direct HTML scraping of `https://github.com/trending/{language}?since=daily`
- Parses repo slugs from `<h2 class="h3 lh-condensed"><a href="/owner/repo">` elements using a regex, returning the same `%{"url" => ...}` map structure the rest of the pipeline expects — no structural changes downstream
- Fixes scheduler config bug: cron job now calls `process_languages/0` instead of `analyze/0` (which doesn't exist — `analyze/1` requires a language argument)
- Adds a unit test for the HTML parser (`parse_trending_html/1`)

## Test plan

- [x] `mix test apps/lowendinsight_get/test/lowendinsight_get/github_trending_test.exs --exclude network` passes (2 tests, 0 failures)
- [ ] Manual/network: `LowendinsightGet.GithubTrending.analyze("elixir")` returns `{:ok, "successfully started analyzing..."}` with live Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)